### PR TITLE
Support for parsing Unix timestamps and modified "null" behaviour

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/Defaults.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/Defaults.java
@@ -37,6 +37,7 @@ public class Defaults {
 
     private static String serviceRoot = GWT.getModuleBaseURL();
     private static String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    private static boolean ignoreJsonNulls = false;
     // patch TNY: timeout ms,
     // if >-1, used in Method class to set timeout
     private static int requestTimeout = -1;
@@ -58,7 +59,7 @@ public class Defaults {
         }
         Defaults.serviceRoot = serviceRoot;
     }
-
+    
     public static String getDateFormat() {
         return dateFormat;
     }
@@ -70,6 +71,21 @@ public class Defaults {
      */
     public static void setDateFormat(String dateFormat) {
         Defaults.dateFormat = dateFormat;
+    }
+
+    /**
+     * Indicates whether or not nulls will be ignored during JSON marshalling.
+     */
+    public static boolean doesIgnoreJsonNulls() {
+        return ignoreJsonNulls;
+    }
+
+    public static void ignoreJsonNulls() {
+        ignoreJsonNulls = true;
+    }
+
+    public static void dontIgnoreJsonNulls() {
+        ignoreJsonNulls = false;
     }
 
     public static final int getRequestTimeout() {


### PR DESCRIPTION
As far as I am aware, Resty has no JSON support for converting between a "long" Unix timestamp and a "Date" object. I have modified the encoder/decoder class so that this will work when "Defaults.dateFormat" is null. The "dateFormat" property has a default value, so this should not cause backward compatibility issues.

I've recently made some posts about inconsistent handling of null values. I decided to go ahead and change this too. There is now a property called "Defaults.ignoreJsonNulls" that will determine whether or not null values should be included in JSON messages. However, I consider this to be a stop-gap solution; it would be ideal if this could be done on a per-service basis, such as the example below.

@POST
public void post(..., @IgnoreNulls Model model, ...);
