### PR TITLE
Adding accessors to RestServiceProxy interface

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/RestServiceProxy.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/RestServiceProxy.java
@@ -26,6 +26,10 @@ public interface RestServiceProxy {
 
     void setResource(Resource resource);
 
+    Resource getResource();
+    
     void setDispatcher(Dispatcher dispatcher);
+    
+    Dispatcher getDispatcher();
 
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -170,6 +170,12 @@ public class RestServiceClassCreator extends BaseSourceCreator {
         }
         i(-1).p("}");
 
+        p("public " + RESOURCE_CLASS + " getResource() {").i(1);
+        {
+            p("return this.resource;");
+        }
+        i(-1).p("}");
+
 
         Options options = source.getAnnotation(Options.class);
         if( options!=null && options.dispatcher()!=Dispatcher.class ) {
@@ -182,6 +188,13 @@ public class RestServiceClassCreator extends BaseSourceCreator {
         p("public void setDispatcher(" + DISPATCHER_CLASS + " dispatcher) {").i(1);
         {
             p("this.dispatcher = dispatcher;");
+        }
+        i(-1).p("}");
+
+        p();
+        p("public " + DISPATCHER_CLASS + " getDispatcher() {").i(1);
+        {
+            p("return this.dispatcher;");
         }
         i(-1).p("}");
 


### PR DESCRIPTION
Added getResource() and getDispatcher to RestServiceProxy and the analogous modifications to the RestServiceProxyGenerator.

Getting the Resource from a proxy is handy when generating urls for sub-resources without perfect knowledge of the url context of the parent interface.
