### PR TITLE
XSRFTokenCallbackFilter didn't set the XSRF token correctly in IE9

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/callback/XSRFTokenCallbackFilter.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/callback/XSRFTokenCallbackFilter.java
@@ -36,7 +36,8 @@ public class XSRFTokenCallbackFilter implements CallbackFilter {
     public RequestCallback filter(final Method method, final Response response,
             RequestCallback callback) {
         String token = response.getHeader(this.xsrf.getHeaderKey());
-        if (token != null && response.getHeader(QueueableCacheStorage.RESTY_CACHE_HEADER) == null){
+        String restyCacheHeader = response.getHeader(QueueableCacheStorage.RESTY_CACHE_HEADER);
+        if (token != null && (restyCacheHeader == null || restyCacheHeader.isEmpty())){
             this.xsrf.setToken(token);
         }
         return callback;


### PR DESCRIPTION
IE9 returns empty string instead of null from xmlHttpRequest.getResponseHeader()
