### PR TITLE
Re-fix of #72

### DIFF
--- a/restygwt/pom.xml
+++ b/restygwt/pom.xml
@@ -77,6 +77,18 @@
         <version>3.0</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+    	<groupId>org.jboss.resteasy</groupId>
+    	<artifactId>resteasy-jaxrs</artifactId>
+    	<version>${resteasy.version}</version>
+    	<scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>org.jboss.resteasy</groupId>
+    	<artifactId>resteasy-jackson-provider</artifactId>
+    	<version>${resteasy.version}</version>
+    	<scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -175,4 +187,7 @@
 
   </profiles>
 
+  <properties>
+  	<resteasy.version>2.3.4.Final</resteasy.version>
+  </properties>
 </project>

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import org.fusesource.restygwt.client.AbstractJsonEncoderDecoder;
 import org.fusesource.restygwt.client.Json;
 import org.fusesource.restygwt.client.Json.Style;
+import org.fusesource.restygwt.client.ObjectEncoderDecoder;
 
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
@@ -104,6 +105,8 @@ public class JsonEncoderDecoderInstanceLocator {
         builtInEncoderDecoders.put(JSON_VALUE_TYPE, JSON_ENCODER_DECODER_CLASS + ".JSON_VALUE");
 
         builtInEncoderDecoders.put(find(Date.class), JSON_ENCODER_DECODER_CLASS + ".DATE");
+        
+        builtInEncoderDecoders.put(find(Object.class), ObjectEncoderDecoder.class.getName() + ".INSTANCE");
 
     }
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/ObjectEncoderDecoder.gwt.xml
+++ b/restygwt/src/test/java/org/fusesource/restygwt/ObjectEncoderDecoder.gwt.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2009-2011 the original author or authors.
+    See the notice.md file distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<module>
+    <inherits name='com.google.gwt.user.User' />
+    <inherits name='com.google.gwt.logging.Logging'/>
+    <inherits name='org.fusesource.restygwt.RestyGWT'/>
+    
+    <servlet path='/properties/*' class='org.fusesource.restygwt.server.complex.ObjectEncoderDecoderServlet' />  --> 
+
+    <source path='client'/>
+</module>

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/complex/ObjectEncoderDecoderTest.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/complex/ObjectEncoderDecoderTest.java
@@ -1,0 +1,102 @@
+package org.fusesource.restygwt.client.complex;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import org.fusesource.restygwt.client.Method;
+import org.fusesource.restygwt.client.MethodCallback;
+import org.fusesource.restygwt.client.RestService;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.junit.client.GWTTestCase;
+
+public class ObjectEncoderDecoderTest extends GWTTestCase
+{
+	@Override
+	public String getModuleName()
+	{
+		return "org.fusesource.restygwt.ObjectEncoderDecoder";
+	}
+
+	public static interface Properties
+	{
+		@GET
+		@Path("{name}")
+		Object getProperty(@PathParam("name") String name);
+
+		@PUT
+		@Path("{name}")
+		void setProperty(@PathParam("name") String name, Object value);
+	}
+
+	@Path("/properties")
+	public static interface PropertiesAsync extends RestService
+	{
+		@GET
+		@Path("{name}")
+		void getProperty(@PathParam("name") String name, MethodCallback<Object> callback);
+
+		@PUT
+		@Path("{name}")
+		void setProperty(@PathParam("name") String name, Object value, MethodCallback<Void> callback);
+	}
+
+	private void performTest(final String property, final Object expected)
+	{
+		PropertiesAsync properties = GWT.create(PropertiesAsync.class);
+		properties.getProperty(property, new MethodCallback<Object>()
+		{
+			@Override
+			public void onFailure(Method method, Throwable exception)
+			{
+				fail(exception.getMessage());
+			}
+
+			@Override
+			public void onSuccess(Method method, Object response)
+			{
+				assertEquals(expected, response);
+				finishTest();
+			}
+		});
+		delayTestFinish(10000);
+	}
+
+	public void testNumber()
+	{
+		performTest("number", 123.0);
+	}
+
+	public void testString()
+	{
+		performTest("string", "Fred Fredstofferson");
+	}
+
+	public void testBoolean()
+	{
+		performTest("boolean", true);
+	}
+
+	public void testArray()
+	{
+		List<Object> list = new ArrayList<Object>();
+		list.add(123.0);
+		list.add(true);
+		list.add("Fred Fredstofferson");
+		performTest("array", list);
+	}
+
+	public void testMap()
+	{
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("blah", 123.0);
+		performTest("object", map);
+	}
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/JsonStringProvider.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/JsonStringProvider.java
@@ -1,0 +1,56 @@
+package org.fusesource.restygwt.server.complex;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class JsonStringProvider implements MessageBodyWriter<String>, MessageBodyReader<String>
+{
+	@Override
+	public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
+	{
+		return type == String.class && MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType);
+	}
+
+	@Override
+	public long getSize(String t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
+	{
+		return -1;
+	}
+
+	@Override
+	public void writeTo(String t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException
+	{
+		// TODO: issue of encoding here???
+		new ObjectMapper().writeValue(entityStream, t);
+	}
+
+	@Override
+	public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
+	{
+		return type == String.class && MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType);
+	}
+
+	@Override
+	public String readFrom(Class<String> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException
+	{
+		// TODO: issue of encoding here???
+		return new ObjectMapper().readValue(entityStream, String.class);
+	}
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/ObjectEncoderDecoderServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/ObjectEncoderDecoderServlet.java
@@ -1,0 +1,63 @@
+package org.fusesource.restygwt.server.complex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.ws.rs.Path;
+
+import org.fusesource.restygwt.client.complex.ObjectEncoderDecoderTest;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.jboss.resteasy.spi.Registry;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import com.google.gwt.dev.util.collect.Maps;
+
+public class ObjectEncoderDecoderServlet extends HttpServletDispatcher
+{
+	private static final long serialVersionUID = 1L;
+
+	private static final Map<String, Object> properties = new HashMap<String, Object>();
+
+	static
+	{
+		properties.put("number", 123.0);
+		properties.put("boolean", true);
+		properties.put("string", "Fred Fredstofferson");
+		properties.put("array", new Object[]
+		{
+				123.0, true, "Fred Fredstofferson"
+		});
+		properties.put("object", Maps.create("blah", 123.0));
+	}
+
+	@Path("properties")
+	public static class PropertiesImpl implements ObjectEncoderDecoderTest.Properties
+	{
+		@Override
+		public Object getProperty(String name)
+		{
+			return properties.get(name);
+		}
+
+		@Override
+		public void setProperty(String name, Object value)
+		{
+			properties.put(name, value);
+		}
+	}
+
+	@Override
+	public void init(ServletConfig config) throws ServletException
+	{
+		super.init(config);
+
+		final ResteasyProviderFactory providerFactory = (ResteasyProviderFactory) config.getServletContext().getAttribute(ResteasyProviderFactory.class.getName());
+		providerFactory.registerProvider(JsonStringProvider.class);
+
+		final Registry registry = (Registry) config.getServletContext().getAttribute(Registry.class.getName());
+		// the prefix must be manually specified because the config's servlet context is does not properly specify it.
+		registry.addPerRequestResource(PropertiesImpl.class, "/org.fusesource.restygwt.ObjectEncoderDecoder.JUnit");
+	}
+}


### PR DESCRIPTION
Apparently the ObjectEncoderDecoder was removed as part of reorganizing of the JsonEncoderDecoderInstanceLocator.  This changeset adds it back along with some additional tests that ensure that it works stem-to-stern.

This also introduces Resteasy into the test scope for use in easily creating tests that utilize resteasy on the server-side.  See ObjectEncoderDecoderServlet for an example of how to set this up.

Thanks!
