### PR TITLE
Fixed a bug using FormParams where List and Arrays were not serialized correctly.

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -661,7 +661,7 @@ public class RestServiceClassCreator extends BaseSourceCreator {
                 OVERLAY_VALUE_TYPE.isAssignableFrom(type.isClass())) {
             return "(new " + JSON_OBJECT_CLASS + "(" + expr + ")).toString()";
         }
-        if (type.getQualifiedBinaryName().startsWith("java.")) {
+        if (type.getQualifiedBinaryName().startsWith("java.lang.")) {
             return String.format("(%s != null ? %s.toString() : null)", expr, expr);
         }
 


### PR DESCRIPTION
Let me first apologize for not testing sufficiently the feature I've added.

I've noticed that my handling of form params didn't parsed correctly Arrays, List and Maps of DTOs, because my assumption was the object's toString() would be correct if it's a java.\* object. Since lists are java.util.List objects, the seralizing to JSON wasn't performed for them. 

Thus I fixed it by checking if the given class is in java.lang.\* and updated the test case for this.
