### PR TITLE
Reduced loglevel for type encoder information to debug

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
@@ -197,7 +197,7 @@ public class JsonEncoderDecoderInstanceLocator {
                     error("List must define one and only one type parameter");
                 }
                 encoderDecoder = getEncoderDecoder(types[0], logger);
-                info("type encoder for: " + types[0] + " is " + encoderDecoder);
+                debug("type encoder for: " + types[0] + " is " + encoderDecoder);
                 if (encoderDecoder != null) {
                     return listMethod + "(" + expression + ", " + encoderDecoder + ")";
                 }
@@ -210,7 +210,7 @@ public class JsonEncoderDecoderInstanceLocator {
             }
             
             encoderDecoder = getEncoderDecoder(componentType, logger);
-            info("type encoder for: " + componentType + " is " + encoderDecoder);
+            debug("type encoder for: " + componentType + " is " + encoderDecoder);
             if (encoderDecoder != null) {
                 if (encoderMethod.equals("encode")) {
                     return arrayMethod + "(" + expression + ", " + encoderDecoder + ")";


### PR DESCRIPTION
Hey,

in bigger projects with many dto there are a lot of messages when compiling like this:

[INFO]    Computing all possible rebind results for 'client.common.services.UserService'
[INFO]       Rebinding client.common.services.UserService
[INFO]          Invoking generator org.fusesource.restygwt.rebind.RestServiceGenerator
[INFO]             Generating: client.common.services.UserService_Generated_RestServiceProxy_
[INFO]                Generating: client.common.dto.Course_Generated_JsonEncoderDecoder_
[INFO]                   type encoder for: class java.lang.String is org.fusesource.restygwt.client.AbstractJsonEncoderDecoder.STRING
[INFO]                   type encoder for: class java.lang.String is org.fusesource.restygwt.client.AbstractJsonEncoderDecoder.STRING
[INFO]                type encoder for: class client.common.dto.Course is client.common.dto.Course_Generated_JsonEncoderDecoder_.INSTANCE

The log output of the generator step becomes really scattered and makes it hard to find other messages which may report a problem.

For me this information sounds like a debugging information. Can the logging level for this message reduced to debug?

Cheers,
Johannes
