### PR TITLE
HTTP 204 issue with MSIE

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
@@ -73,6 +73,8 @@ public class Method {
       expectedStatuses.add(200);
       expectedStatuses.add(201);
       expectedStatuses.add(204);
+      // This is needed for MSIE mangling with status 204 to become 1223
+      expectedStatuses.add(1223);
     };
     boolean anyStatus;
 


### PR DESCRIPTION
HTTP 204 issue with MSIE

Issue is well documented here:
http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request

I understand that we can add our own expected statuses through @Options, but I do not necessary want to declare that in all my HTTP requests.
