### PR TITLE
Automatic discovery of subtypes for @JsonTypeInfo

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -116,15 +116,19 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
         if (typeInfo != null) {
             final JsonSubTypes jacksonSubTypes = findAnnotation(source, JsonSubTypes.class);
             if (typeInfo.use() == Id.CLASS || typeInfo.use() == Id.MINIMAL_CLASS) {
+            List<JClassType> resolvedSubtypes = Lists.newArrayList();
         	if (jacksonSubTypes != null) {
         	    for (JsonSubTypes.Type type : jacksonSubTypes.value()) {
         		JClassType typeClass = find(type.value());
-        		if (!isLeaf || source.equals(typeClass))
-        		    possibleTypes.add(new Subtype(typeInfo.use() == Id.CLASS ? typeClass.getQualifiedSourceName() : typeClass.getSimpleSourceName(), typeClass));
+        		if (!isLeaf || source.equals(typeClass)) resolvedSubtypes.add(typeClass);
         	    }
         	} else {
-        	    error("@JsonSubTypes annotation missing for type: " + source);
+        		for (JClassType typeClass : context.getTypeOracle().getTypes()) {
+    			if (!typeClass.isAbstract() && typeClass.isAssignableTo(source)) resolvedSubtypes.add(typeClass);
+        		}
         	}
+        	for (JClassType typeClass : resolvedSubtypes)
+        	possibleTypes.add(new Subtype(typeInfo.use() == Id.CLASS ? typeClass.getQualifiedSourceName() : "." + typeClass.getSimpleSourceName(), typeClass));
             } else if (typeInfo.use() != Id.NONE) {
         	final JsonTypeIdResolver typeResolver = findAnnotation(source, JsonTypeIdResolver.class);
         	if (jacksonSubTypes != null) {


### PR DESCRIPTION
Hi,
I have found quite simple way to discovery all subtypes of generic type annotated with @JsonTypeInfo (in case of use=CLASS or MINIMAL_CLASS).
I just use TypeOracle to get all available types and I find types assignable to source type, such subtype I add to possible types in same way as for subtypes resolved from @JsonSubTypes annotation.
With this update you need not to use the @JsonSubTypes annotation anymore, as with pure Jackson library.
My motivation was to reuse the entities generated by JAXB also for GWT, for which defining the @JsonSubTypes for all specific types was quite verbose and not maintainable (via the annox:annotation plugin).

I have also fixed subtype tag mapping for MINIMAL_CLASS, where jackson uses a dot as a prefix. In reality the MINIMAL_CLASS tag is a bit more complicated in jackson library as it computes the shortest path including the packages in which the subtypes differ (prepended with the leading dot, of course), but I think it is ok to leave it as it is for now.

If you like this change you are welcome to accept it into your master branch.

Regards,
Michal Moravcik
