### PR TITLE
Fix Eclipse web.xml validation

### DIFF
--- a/restygwt/src/it/restygwt-rails-example/src/main/webapp/WEB-INF/web.xml
+++ b/restygwt/src/it/restygwt-rails-example/src/main/webapp/WEB-INF/web.xml
@@ -22,10 +22,6 @@
 "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
 "http://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app>
-  <welcome-file-list>
-    <welcome-file>/index.html</welcome-file>
-  </welcome-file-list>
-
   <context-param>
     <param-name>jruby.max.runtimes</param-name>
     <param-value>1</param-value>
@@ -54,4 +50,8 @@
     <res-auth>Container</res-auth>
   </resource-ref>
 -->
+
+  <welcome-file-list>
+    <welcome-file>/index.html</welcome-file>
+  </welcome-file-list>
 </web-app>


### PR DESCRIPTION
Eclipse web.xml validation does not accept  welcome-file-list as the first entry into the web.xml.

Push it to the end of the file.
