### PR TITLE
Refactor the getPossibleType method in JsonEncoderDecoderClassCreator

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/ExtendedJsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/ExtendedJsonEncoderDecoderClassCreator.java
@@ -42,8 +42,8 @@ public class ExtendedJsonEncoderDecoderClassCreator extends BaseSourceCreator {
 
     protected ClassSourceFileComposerFactory createComposerFactory() throws UnableToCompleteException {
         ClassSourceFileComposerFactory composerFactory = new ClassSourceFileComposerFactory(packageName, shortName);
-        JClassType encodedType = getEncodedType(logger, context, source);
-        JsonEncoderDecoderClassCreator generator = new JsonEncoderDecoderClassCreator(logger, context, encodedType);
+        JClassType encodedType = getEncodedType(getLogger(), context, source);
+        JsonEncoderDecoderClassCreator generator = new JsonEncoderDecoderClassCreator(getLogger(), context, encodedType);
         composerFactory.setSuperclass(generator.create());
         composerFactory.addImplementedInterface(source.getQualifiedSourceName());
         return composerFactory;
@@ -52,29 +52,29 @@ public class ExtendedJsonEncoderDecoderClassCreator extends BaseSourceCreator {
     private JClassType getEncodedType(TreeLogger logger, GeneratorContext context, JClassType type) throws UnableToCompleteException {
         JClassType intf = type.isInterface();
         if (intf == null) {
-            error("Expected " + type + " to be an interface.");
+            getLogger().log(ERROR, "Expected " + type + " to be an interface.");
             throw new UnableToCompleteException();
         }
 
         JClassType[] intfs = intf.getImplementedInterfaces();
         for (JClassType t : intfs) {
-            info("checking: " + t.getQualifiedSourceName() + ", type: " + t.getClass());
+            getLogger().log(INFO, "checking: " + t.getQualifiedSourceName() + ", type: " + t.getClass());
             if (t.getQualifiedSourceName().equals(JSON_ENCODER_DECODER)) {
 
                 JParameterizedType genericType = t.isParameterized();
                 if (genericType == null) {
-                    error("Expected the " + JSON_ENCODER_DECODER + " declaration to specify a parameterized type.");
+                    getLogger().log(ERROR, "Expected the " + JSON_ENCODER_DECODER + " declaration to specify a parameterized type.");
                     throw new UnableToCompleteException();
                 }
                 JClassType[] typeParameters = genericType.getTypeArgs();
                 if (typeParameters == null || typeParameters.length != 1) {
-                    error("Expected the " + JSON_ENCODER_DECODER + " declaration to specify 1 parameterized type.");
+                    getLogger().log(ERROR, "Expected the " + JSON_ENCODER_DECODER + " declaration to specify 1 parameterized type.");
                     throw new UnableToCompleteException();
                 }
                 return typeParameters[0].isClass();
             }
         }
-        error("Expected  " + type + " to extend the " + JSON_ENCODER_DECODER + " interface.");
+        getLogger().log(ERROR, "Expected  " + type + " to extend the " + JSON_ENCODER_DECODER + " interface.");
         throw new UnableToCompleteException();
     }
 

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -31,10 +31,6 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonSubTypes;
 import org.codehaus.jackson.annotate.JsonTypeInfo;
 import org.codehaus.jackson.annotate.JsonTypeInfo.As;
-import org.codehaus.jackson.annotate.JsonTypeInfo.Id;
-import org.codehaus.jackson.annotate.JsonTypeName;
-import org.codehaus.jackson.map.annotate.JsonTypeIdResolver;
-import org.codehaus.jackson.map.jsontype.TypeIdResolver;
 import org.fusesource.restygwt.client.Json;
 import org.fusesource.restygwt.client.Json.Style;
 
@@ -83,52 +79,28 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
     }
 
     @Override
-    protected ClassSourceFileComposerFactory createComposerFactory() {
-	ClassSourceFileComposerFactory composerFactory = new ClassSourceFileComposerFactory(packageName, shortName);
-	composerFactory.setSuperclass(JSON_ENCODER_DECODER_CLASS + "<" + source.getParameterizedQualifiedSourceName() + ">");
-	return composerFactory;
-    }
-
-    private static class Subtype {
-	final String tag;
-	final JClassType clazz;
-
-	public Subtype(String tag, JClassType clazz) {
-	    this.tag = tag;
-	    this.clazz = clazz;
-	}
-    }
-
-    private static <T extends Annotation> T findAnnotation(JClassType clazz, Class<T> annotation) {
-	if (clazz == null)
-	    return null;
-	else if (clazz.isAnnotationPresent(annotation))
-	    return clazz.getAnnotation(annotation);
-	else
-	    return findAnnotation(clazz.getSuperclass(), annotation);
-    }
-
-    @Override
     public void generate() throws UnableToCompleteException {
         final JsonTypeInfo typeInfo = findAnnotation(source, JsonTypeInfo.class);
         final boolean isLeaf = isLeaf(source);
         
-        final List<Subtype> possibleTypes = getPossibleTypes(context, source, typeInfo, isLeaf, logger);
+        final List<Subtype> possibleTypes = getPossibleTypes(typeInfo, isLeaf);
     
         JClassType sourceClazz = source.isClass();
         if (sourceClazz == null) {
-            error("Type is not a class");
+            getLogger().log(ERROR, "Type is not a class");
+            throw new UnableToCompleteException();
         }   
     
         if (sourceClazz.isAbstract()) {
             if (typeInfo == null) {
-        	error("Abstract classes must be annotated with JsonTypeInfo");
+                getLogger().log(ERROR, "Abstract classes must be annotated with JsonTypeInfo");
+                throw new UnableToCompleteException();
             }
         }
         Json jsonAnnotation = source.getAnnotation(Json.class);
         final Style classStyle = jsonAnnotation != null ? jsonAnnotation.style() : Style.DEFAULT;
         final String railsWrapperName = jsonAnnotation != null && jsonAnnotation.name().length() > 0 ? jsonAnnotation.name() : sourceClazz.getName().toLowerCase();
-        locator = new JsonEncoderDecoderInstanceLocator(context, logger);
+        locator = new JsonEncoderDecoderInstanceLocator(context, getLogger());
     
         generateSingleton(shortName);
         
@@ -137,79 +109,30 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
         generateDecodeMethod(source, classStyle, typeInfo, railsWrapperName, possibleTypes, isLeaf, locator);
     }
 
-    private List<Subtype> getPossibleTypes(GeneratorContext context, JClassType classType, final JsonTypeInfo typeInfo, final boolean isLeaf, TreeLogger logger)
-            throws UnableToCompleteException
+    @Override
+    protected ClassSourceFileComposerFactory createComposerFactory() {
+	ClassSourceFileComposerFactory composerFactory = new ClassSourceFileComposerFactory(packageName, shortName);
+	composerFactory.setSuperclass(JSON_ENCODER_DECODER_CLASS + "<" + source.getParameterizedQualifiedSourceName() + ">");
+	return composerFactory;
+    }
+
+    public static <T extends Annotation> T findAnnotation(JClassType clazz, Class<T> annotation) {
+	if (clazz == null)
+	    return null;
+	else if (clazz.isAnnotationPresent(annotation))
+	    return clazz.getAnnotation(annotation);
+	else
+	    return findAnnotation(clazz.getSuperclass(), annotation);
+    }
+
+    private List<Subtype> getPossibleTypes(final JsonTypeInfo typeInfo, final boolean isLeaf) throws UnableToCompleteException
     {
-        final List<Subtype> possibleTypes = Lists.newArrayList();
-        if (typeInfo != null) {
-            final JsonSubTypes jacksonSubTypes = findAnnotation(classType, JsonSubTypes.class);
-            if (typeInfo.use() == Id.CLASS || typeInfo.use() == Id.MINIMAL_CLASS) {
-            List<JClassType> resolvedSubtypes = Lists.newArrayList();
-        	if (jacksonSubTypes != null) {
-        	    for (JsonSubTypes.Type type : jacksonSubTypes.value()) {
-        		JClassType typeClass = find(type.value());
-        		if (!isLeaf || classType.equals(typeClass)) resolvedSubtypes.add(typeClass);
-        	    }
-        	} else {
-        		for (JClassType typeClass : context.getTypeOracle().getTypes()) {
-    			if (!typeClass.isAbstract() && typeClass.isAssignableTo(classType)) resolvedSubtypes.add(typeClass);
-        		}
-        	}
-        	for (JClassType typeClass : resolvedSubtypes)
-        	possibleTypes.add(new Subtype(typeInfo.use() == Id.CLASS ? typeClass.getQualifiedSourceName() : "." + typeClass.getSimpleSourceName(), typeClass));
-            } else if (typeInfo.use() != Id.NONE) {
-        	final JsonTypeIdResolver typeResolver = findAnnotation(classType, JsonTypeIdResolver.class);
-        	if (jacksonSubTypes != null) {
-        	    for (JsonSubTypes.Type type : jacksonSubTypes.value()) {
-        		if (type.name() != null && !type.name().isEmpty()) {
-        		    JClassType typeClass = find(type.value());
-        		    if (!isLeaf || classType.equals(typeClass))
-        			possibleTypes.add(new Subtype(type.name(), typeClass));
-        		} else {
-        		    JsonTypeName nameAnnotation = type.value().getAnnotation(JsonTypeName.class);
-        		    if (nameAnnotation == null || nameAnnotation.value() == null || nameAnnotation.value().isEmpty())
-        			error("Cannot find @JsonTypeName annotation for type: " + type.value());
-        		    JClassType typeClass = find(type.value());
-        		    if (!isLeaf || classType.equals(typeClass))
-        			possibleTypes.add(new Subtype(nameAnnotation.value(), typeClass));
-        		}
-        	    }
-        	    if (isLeaf && possibleTypes.size() == 0)
-        		error("Could not find @JsonSubTypes entry for type: " + classType);
-        	} else if (typeResolver != null) {
-        	    Class<? extends TypeIdResolver> resolverClass = typeResolver.value();
-        	    RestyJsonTypeIdResolver restyResolver;
-        	    if (RestyJsonTypeIdResolver.class.isAssignableFrom(resolverClass)) {
-        		try {
-        		    restyResolver = (RestyJsonTypeIdResolver) resolverClass.newInstance();
-        		} catch (Exception e) {
-        		    logger.log(ERROR, "Could not acccess: " + resolverClass, e);
-        		    throw new UnableToCompleteException();
-        		}
-        	    } else {
-        		restyResolver = getRestyResolverClassMap(context, logger).get(resolverClass);
-        		if (restyResolver == null)
-        		    error("Could not find RestyJsonTypeIdResolver for " + resolverClass + " did you forget to put <extend-configuration-property name=\"org.fusesource.restygwt.jsontypeidresolver\" value=\"<fully-qualified-class-implementing-RestyJsonTypeIdResolver>\"/> in your *.gwt.xml?");
-        	    }
-    
-        	    for (Map.Entry<String, Class<?>> entry : restyResolver.getIdClassMap().entrySet()) {
-        		JClassType entryType = find(entry.getValue());
-        		if (!isLeaf || classType.equals(entryType))
-        		    possibleTypes.add(new Subtype(entry.getKey(), entryType));
-        	    }
-        	    if (isLeaf && possibleTypes.size() == 0)
-        		error("Could not find entry in " + restyResolver.getClass().getName() + " for type: " + classType);
-        	} else {
-        	    error("Cannot find required subtype resolution for type: " + classType);
-        	}
-            } else {
-        	error("Id.NONE not supported");
-            }
-        } else {
-            possibleTypes.add(new Subtype(null, classType));
+        if (typeInfo == null)
+            return Lists.newArrayList(new Subtype(null, source));
+        else {
+            PossibleTypesVisitor v = new PossibleTypesVisitor(context, source, isLeaf, getLogger(), findAnnotation(source, JsonSubTypes.class));
+            return v.visit(typeInfo.use());
         }
-        
-        return possibleTypes;
     }
 
     private void generateSingleton(String shortName)
@@ -355,7 +278,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                     i(-1).p("}");
     
                     } else {
-                        logger.log(ERROR, "private field gets ignored: " + field.getEnclosingType().getQualifiedSourceName() + "." + field.getName());
+                        getLogger().log(ERROR, "private field gets ignored: " + field.getEnclosingType().getQualifiedSourceName() + "." + field.getName());
                     }
                     return null;
                 }
@@ -557,7 +480,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                         i(-1).p("}");    
 
                     } else {
-                        logger.log(ERROR, "private field gets ignored: " + field.getEnclosingType().getQualifiedSourceName() + "." + field.getName());
+                        getLogger().log(ERROR, "private field gets ignored: " + field.getEnclosingType().getQualifiedSourceName() + "." + field.getName());
                     }
                     return null;
                     }
@@ -601,9 +524,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
         p();
     }
     
-    private static Map<Class<?>, RestyJsonTypeIdResolver> sTypeIdResolverMap = null;
-
-    private static Map<Class<?>, RestyJsonTypeIdResolver> getRestyResolverClassMap(GeneratorContext context, TreeLogger logger) throws UnableToCompleteException {
+    public static Map<Class<?>, RestyJsonTypeIdResolver> getRestyResolverClassMap(GeneratorContext context, TreeLogger logger) throws UnableToCompleteException {
 	if (sTypeIdResolverMap == null) {
 	    try {
 		Map<Class<?>, RestyJsonTypeIdResolver> map = Maps.newHashMap();
@@ -636,7 +557,8 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
 		    }
 		}
 	    } else {
-		error("a constructor annotated with @JsonCreator requires that all paramaters are annotated with @JsonProperty.");
+		getLogger().log(ERROR, "a constructor annotated with @JsonCreator requires that all paramaters are annotated with @JsonProperty.");
+        throw new UnableToCompleteException();
 	    }
 	}
 
@@ -680,7 +602,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
 	String fieldName = field.getName();
 	JType booleanType = null;
 	try {
-	    booleanType = find(Boolean.class);
+	    booleanType = find(Boolean.class, getLogger(), context);
 	} catch (UnableToCompleteException e) {
 	    // do nothing
 	}
@@ -737,7 +659,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
 	    return true;
 	} else {
 	    try {
-		JType objectType = find(Object.class);
+		JType objectType = find(Object.class, getLogger(), context);
 		JClassType superType = type.getSuperclass();
 		if (!objectType.equals(superType)) {
 		    return exists(superType, field, fieldName, isSetter);
@@ -800,7 +722,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
             }
         }
         try {
-            JType objectType = find(Object.class);
+            JType objectType = find(Object.class, getLogger(), context);
             if (!objectType.equals(type)) {
                 JClassType superType = type.getSuperclass();
                 return getFields(allFields, superType);
@@ -826,4 +748,16 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
     {
         return !(source.getSubtypes() != null && source.getSubtypes().length > 0);
     }
+
+    public static class Subtype {
+    final String tag;
+    final JClassType clazz;
+    
+    public Subtype(String tag, JClassType clazz) {
+        this.tag = tag;
+        this.clazz = clazz;
+    }
+    }
+
+    private static Map<Class<?>, RestyJsonTypeIdResolver> sTypeIdResolverMap = null;
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
@@ -1,0 +1,168 @@
+package org.fusesource.restygwt.rebind;
+
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonSubTypes;
+import org.codehaus.jackson.annotate.JsonTypeInfo.Id;
+import org.codehaus.jackson.annotate.JsonTypeName;
+import org.codehaus.jackson.map.annotate.JsonTypeIdResolver;
+import org.codehaus.jackson.map.jsontype.TypeIdResolver;
+import org.fusesource.restygwt.rebind.JsonEncoderDecoderClassCreator.Subtype;
+import org.fusesource.restygwt.rebind.util.JsonTypeInfoIdVisitor;
+
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.core.ext.typeinfo.JClassType;
+import com.google.gwt.thirdparty.guava.common.collect.Lists;
+
+public class PossibleTypesVisitor extends JsonTypeInfoIdVisitor<List<Subtype>, UnableToCompleteException>
+{
+    private GeneratorContext context;
+    private JClassType classType;
+    private boolean isLeaf;
+    private TreeLogger logger;
+    private JsonSubTypes jacksonSubTypes;
+
+    public PossibleTypesVisitor(GeneratorContext context, JClassType classType, final boolean isLeaf, TreeLogger logger, final JsonSubTypes jacksonSubTypes)
+    {
+        this.context = context;
+        this.classType = classType;
+        this.isLeaf = isLeaf;
+        this.logger = logger;
+        this.jacksonSubTypes = jacksonSubTypes;
+    }
+    
+    
+    @Override
+    public List<Subtype> visitClass() throws UnableToCompleteException
+    {
+        return getPossibleTypesForClass(context, classType, Id.CLASS, isLeaf, logger, jacksonSubTypes);
+    }
+
+    @Override
+    public List<Subtype> visitMinClass() throws UnableToCompleteException
+    {
+        return getPossibleTypesForClass(context, classType, Id.MINIMAL_CLASS, isLeaf, logger, jacksonSubTypes);
+    }
+
+
+    @Override
+    public List<Subtype> visitCustom() throws UnableToCompleteException
+    {
+        return getPossibleTypesForOther(context, classType, isLeaf, logger, jacksonSubTypes);
+    }
+
+    @Override
+    public List<Subtype> visitName() throws UnableToCompleteException
+    {
+        return getPossibleTypesForOther(context, classType, isLeaf, logger, jacksonSubTypes);
+    }
+
+    @Override
+    public List<Subtype> visitNone() throws UnableToCompleteException
+    {
+        logger.log(BaseSourceCreator.ERROR, "Id.NONE not supported");
+        throw new UnableToCompleteException();
+    }
+
+    @Override
+    public List<Subtype> visitDefault() throws UnableToCompleteException
+    {
+        return null;
+    }
+
+
+    protected List<Subtype> getPossibleTypesForOther(GeneratorContext context, JClassType classType, final boolean isLeaf, TreeLogger logger,
+            final JsonSubTypes jacksonSubTypes) throws UnableToCompleteException
+    {
+        final List<Subtype> possibleTypes = Lists.newArrayList();  
+        
+        final JsonTypeIdResolver typeResolver = JsonEncoderDecoderClassCreator.findAnnotation(classType, JsonTypeIdResolver.class);
+        if (jacksonSubTypes != null) {
+            for (JsonSubTypes.Type type : jacksonSubTypes.value()) {
+                if (type.name() != null && !type.name().isEmpty()) {
+                    JClassType typeClass = BaseSourceCreator.find(type.value(), logger, context);
+                    if (!isLeaf || classType.equals(typeClass))
+                    possibleTypes.add(new Subtype(type.name(), typeClass));
+                } else {
+                    JsonTypeName nameAnnotation = type.value().getAnnotation(JsonTypeName.class);
+                    if (nameAnnotation == null || nameAnnotation.value() == null || nameAnnotation.value().isEmpty())
+                    {
+                        logger.log(BaseSourceCreator.ERROR, "Cannot find @JsonTypeName annotation for type: " + type.value());
+                        throw new UnableToCompleteException();
+                    }
+                    JClassType typeClass = BaseSourceCreator.find(type.value(), logger, context);
+                    if (!isLeaf || classType.equals(typeClass))
+                    possibleTypes.add(new Subtype(nameAnnotation.value(), typeClass));
+                }
+            }
+            if (isLeaf && possibleTypes.size() == 0)
+            {
+                logger.log(BaseSourceCreator.ERROR, "Could not find @JsonSubTypes entry for type: " + classType);
+                throw new UnableToCompleteException();
+            }
+        } else if (typeResolver != null) {
+            Class<? extends TypeIdResolver> resolverClass = typeResolver.value();
+            RestyJsonTypeIdResolver restyResolver;
+            if (RestyJsonTypeIdResolver.class.isAssignableFrom(resolverClass)) {
+            try {
+                restyResolver = (RestyJsonTypeIdResolver) resolverClass.newInstance();
+            } catch (Exception e) {
+                logger.log(BaseSourceCreator.ERROR, "Could not acccess: " + resolverClass, e);
+                throw new UnableToCompleteException();
+            }
+            } else {
+            restyResolver = JsonEncoderDecoderClassCreator.getRestyResolverClassMap(context, logger).get(resolverClass);
+            if (restyResolver == null)
+            {
+                logger.log(BaseSourceCreator.ERROR, "Could not find RestyJsonTypeIdResolver for " + resolverClass + " did you forget to put <extend-configuration-property name=\"org.fusesource.restygwt.jsontypeidresolver\" value=\"<fully-qualified-class-implementing-RestyJsonTypeIdResolver>\"/> in your *.gwt.xml?");
+                throw new UnableToCompleteException();
+            }
+            }
+    
+            for (Map.Entry<String, Class<?>> entry : restyResolver.getIdClassMap().entrySet()) {
+            JClassType entryType = BaseSourceCreator.find(entry.getValue(), logger, context);
+            if (!isLeaf || classType.equals(entryType))
+                possibleTypes.add(new Subtype(entry.getKey(), entryType));
+            }
+            if (isLeaf && possibleTypes.size() == 0)
+            {
+                logger.log(BaseSourceCreator.ERROR, "Could not find entry in " + restyResolver.getClass().getName() + " for type: " + classType);
+                throw new UnableToCompleteException();
+            }
+        } else {
+            logger.log(BaseSourceCreator.ERROR, "Cannot find required subtype resolution for type: " + classType);
+            throw new UnableToCompleteException();
+        }
+        return possibleTypes;
+    }
+
+    protected List<Subtype> getPossibleTypesForClass(GeneratorContext context, JClassType classType, final Id id, final boolean isLeaf, TreeLogger logger, final JsonSubTypes jacksonSubTypes)
+            throws UnableToCompleteException
+    {
+        final List<Subtype> possibleTypes = Lists.newArrayList();  
+        List<JClassType> resolvedSubtypes = Lists.newArrayList();
+    
+        if (jacksonSubTypes != null) {
+            for (JsonSubTypes.Type type : jacksonSubTypes.value()) {
+                JClassType typeClass = BaseSourceCreator.find(type.value(), logger, context);
+                if (!isLeaf || classType.equals(typeClass)) 
+                    resolvedSubtypes.add(typeClass);
+            }
+        } else {
+            for (JClassType typeClass : context.getTypeOracle().getTypes()) {
+                if (!typeClass.isAbstract() && typeClass.isAssignableTo(classType)) 
+                    resolvedSubtypes.add(typeClass);
+            }
+        }
+        
+        for (JClassType typeClass : resolvedSubtypes)
+            possibleTypes.add(new Subtype(id == Id.CLASS ? typeClass.getQualifiedSourceName() : "." + typeClass.getSimpleSourceName(), typeClass));
+        
+        return possibleTypes;
+    }
+
+
+}

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceGenerator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceGenerator.java
@@ -36,8 +36,7 @@ public class RestServiceGenerator extends Generator {
             JClassType restService = find(logger, context, source);
             RestServiceClassCreator generator = new RestServiceClassCreator(logger, context, restService);
 
-            String generated = generator.create();
-            return generated;
+            return generator.create();
         } finally {
             BaseSourceCreator.clearGeneratedClasses();
         }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/util/JsonTypeInfoIdVisitor.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/util/JsonTypeInfoIdVisitor.java
@@ -1,0 +1,31 @@
+package org.fusesource.restygwt.rebind.util;
+
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+
+public abstract class JsonTypeInfoIdVisitor<OUT, EXCEPTION extends Throwable>
+{
+    public OUT visit(JsonTypeInfo.Id id) throws EXCEPTION {
+        switch (id)
+        {
+            case CLASS:
+                return visitClass();
+            case CUSTOM:
+                return visitCustom();
+            case MINIMAL_CLASS:
+                return visitMinClass();
+            case NAME:
+                return visitName();
+            case NONE:
+                return visitNone();
+            default:
+                return visitDefault();
+        }
+    }
+    
+    public abstract OUT visitClass() throws EXCEPTION;
+    public abstract OUT visitCustom() throws EXCEPTION;
+    public abstract OUT visitMinClass() throws EXCEPTION;
+    public abstract OUT visitName() throws EXCEPTION;
+    public abstract OUT visitNone() throws EXCEPTION;
+    public abstract OUT visitDefault() throws EXCEPTION;
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreatorTestCase.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreatorTestCase.java
@@ -1,0 +1,91 @@
+package org.fusesource.restygwt.rebind;
+
+import java.util.List;
+
+import junit.framework.TestCase;
+
+import org.codehaus.jackson.annotate.JsonSubTypes;
+import org.codehaus.jackson.annotate.JsonTypeInfo.Id;
+import org.fusesource.restygwt.rebind.JsonEncoderDecoderClassCreator.Subtype;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.core.ext.typeinfo.JClassType;
+
+@RunWith(JUnit4.class)
+public class JsonEncoderDecoderClassCreatorTestCase extends TestCase
+{
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    
+    private static class MyPossibleTypesVisitor extends PossibleTypesVisitor {
+
+        boolean hasEnteredGetPossibleTypesForClass;
+        boolean hasEnteredGetPossibleTypesForOther;
+        
+        public MyPossibleTypesVisitor(GeneratorContext context, JClassType classType, boolean isLeaf,
+                TreeLogger logger, JsonSubTypes jacksonSubTypes)
+        {
+            super(context, classType, isLeaf, logger, jacksonSubTypes);
+        }
+        
+        @Override
+        protected List<Subtype> getPossibleTypesForClass(GeneratorContext context, JClassType classType, Id id,
+                boolean isLeaf, TreeLogger logger, JsonSubTypes jacksonSubTypes) throws UnableToCompleteException
+        {
+            hasEnteredGetPossibleTypesForClass = true;
+            return null;
+        }
+        
+        @Override
+        protected List<Subtype> getPossibleTypesForOther(GeneratorContext context, JClassType classType,
+                boolean isLeaf, TreeLogger logger, JsonSubTypes jacksonSubTypes) throws UnableToCompleteException
+        {
+            hasEnteredGetPossibleTypesForOther = true;
+            return null;
+        }
+        
+    }
+    
+    @Test
+    public void testGetPossibleTypesForClass() throws Throwable {
+        check(Id.CLASS, true, false);
+        check(Id.MINIMAL_CLASS, true, false);
+        check(Id.CUSTOM, false, true);
+        check(Id.NAME, false, true);
+    }
+    
+    @Test(expected=UnableToCompleteException.class)
+    public void testGetPossibleTypesForClass2() throws Throwable {
+        check(Id.NONE, false, true);
+    }
+
+    private void check(final Id id, final boolean classMethodVisited, final boolean otherMethodVisited)
+            throws Throwable
+    {
+        MyPossibleTypesVisitor v = new MyPossibleTypesVisitor(null, null, true, new TreeLogger(){         
+            @Override
+            public void log(Type type, String msg, Throwable caught, HelpInfo helpInfo){
+            }
+            
+            @Override
+            public boolean isLoggable(Type type){
+                return false;
+            }
+            
+            @Override
+            public TreeLogger branch(Type type, String msg, Throwable caught, HelpInfo helpInfo){
+                return null;
+            }
+        }, null);        
+        v.visit(id);
+        assertEquals(v.hasEnteredGetPossibleTypesForClass, classMethodVisited);
+        assertEquals(v.hasEnteredGetPossibleTypesForOther, otherMethodVisited);
+    }
+}


### PR DESCRIPTION
This commit is a refactoring of the getPossibleType method in JsonEncoderDecoderClassCreator to make it easier to test the code afterward.

I created a kind of JsonTypeInfo.Id visitor that can be reused for other
matters. I extracted some of code from the JsonEncoderDecoderClassCreator to
put it in a specific visitor which responsibility is to get the possible subtypes for a given class type.

I also remove the logger "wrapper" methods which where IMO useless and error prone as they were sometime always raising exceptions !?

Added a test to test the visitor logic. Not tested the actual code that was pre-existing.
