### PR TITLE
Added support for decoding long strings as proper long values in restygwt

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -139,7 +139,12 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
             if (value == null || value.isNull() != null) {
                 return null;
             }
-            return (long) toDouble(value);
+            final JSONString valueString = value.isString();
+            if (valueString != null) {
+                 return Long.parseLong(valueString.stringValue());
+            } else {
+                return (long) toDouble(value);
+            }
         }
 
         public JSONValue encode(Long value) throws EncodingException {

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
@@ -31,6 +31,8 @@ import java.util.Set;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import java.util.TreeMap;
+import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.fusesource.restygwt.client.AbstractJsonEncoderDecoder;
@@ -45,6 +47,9 @@ import org.fusesource.restygwt.client.RestService;
 
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.junit.client.GWTTestCase;
 
@@ -733,6 +738,17 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         assertEquals("{\"shorty\":0, \"id\":9007199254741116}", json.toString());
         Shorty roundTrip = shortyCodec.decode(json);
         assertEquals(roundTrip.getId(), 9007199254741116l);
+    }
+
+    public void testSuperlongLongsAsString() {
+        ShortyCodec shortyCodec = GWT.create(ShortyCodec.class);
+        
+        JSONObject json = new JSONObject();
+        json.put("shorty", new JSONNumber(0));
+        json.put("id", new JSONString("9007199254741115"));
+        assertEquals("{\"shorty\":0, \"id\":\"9007199254741115\"}", json.toString());
+        Shorty roundTrip = shortyCodec.decode(json);
+        assertEquals(roundTrip.getId(), 9007199254741115l);
     }
     
     static class Bean {


### PR DESCRIPTION
Added support for decoding long strings as proper long values in restygwt, added a testcase verifying the behaviour. Long numbers (not strings) will remain an issue as long as js does not support them properly. Issue #119
