### PR TITLE
Issue# 175 - This code modifies package to avoid the problem described in the issue

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
@@ -77,8 +77,8 @@ public abstract class BaseSourceCreator extends AbstractSourceCreator {
         this.logger = logger;
         this.context = context;
         this.source = source;
-        this.packageName = source.getPackage().getName();
-
+        this.packageName = getOpenPackageName( source.getPackage().getName() );
+        
         if(source instanceof JParameterizedType)
         {
     		JParameterizedType ptype = (JParameterizedType)source;
@@ -106,6 +106,24 @@ public abstract class BaseSourceCreator extends AbstractSourceCreator {
             return source.getSimpleSourceName();
         }
     }
+    
+    /**
+     * Some packages are protected such that any type we generate in that package can't subsequently be loaded
+     * because of a {@link SecurityException}, for example <code>java.</code> and <code>javax.</code> packages. 
+     * <p>
+     * To workaround this issue we add a prefix onto such packages so that the generated code can be loaded
+     * later. The prefix added is <code>open.</code>
+     * 
+     * @param name
+     * @return
+     */
+    private String getOpenPackageName(String name) {
+      if (name.startsWith("java.") || name.startsWith("javax.")) {
+        name = "open."+name;
+      }
+      return name;
+    }
+    
     protected PrintWriter writer() throws UnableToCompleteException {
         HashSet<String> classes = getGeneratedClasses();
         if (classes.contains(name)) {


### PR DESCRIPTION
See issue #175 
 
I think the code is ok, and certainly works for me. It you want, I could modify the code so that the renaming only takes place in JsonEncodeDecoderClassCreator, rather than in every sub-class of BaseSourceCreator. But it seems the other sub-classes would not be subject to the same problem.
