### PR TITLE
Maps: Don't decode key if map key type is String

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/JsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/JsonEncoderDecoder.java
@@ -44,4 +44,5 @@ public interface JsonEncoderDecoder<T> {
 
     public T decode(JSONValue value) throws DecodingException;
 
+    public T decode(String value) throws DecodingException;
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
@@ -414,8 +414,8 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         String[] array = {"may", "all", "be", "happy"};
         AbstractJsonEncoderDecoder<String> encoder = AbstractJsonEncoderDecoder.STRING;
         assertEquals(Arrays.toString(array),
-                Arrays.toString(AbstractJsonEncoderDecoder.toArray(AbstractJsonEncoderDecoder.toJSON(array, encoder), 
-                            encoder, new String[4])));
+                Arrays.toString(AbstractJsonEncoderDecoder.toArray(AbstractJsonEncoderDecoder.toJSON(array, encoder),
+                        encoder, new String[4])));
     }
 
     public void testTypeMapDecode() {
@@ -466,6 +466,40 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
                         Json.Style.JETTISON_NATURAL).toString());
     }
 
+    public void testTypeMapWithLargeDigitStringDecode() {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("1234567890123456789", "321");
+        AbstractJsonEncoderDecoder<String> keyEncoder = AbstractJsonEncoderDecoder.STRING;
+        AbstractJsonEncoderDecoder<String> valueEncoder = AbstractJsonEncoderDecoder.STRING;
+        assertEquals(map.toString(),
+                AbstractJsonEncoderDecoder.toMap(AbstractJsonEncoderDecoder.toJSON(map, keyEncoder, valueEncoder, Json.Style.DEFAULT),
+                        keyEncoder,
+                        valueEncoder,
+                        Json.Style.DEFAULT).toString());
+        assertEquals(map.toString(),
+                AbstractJsonEncoderDecoder.toMap(AbstractJsonEncoderDecoder.toJSON(map, keyEncoder, valueEncoder, Json.Style.JETTISON_NATURAL), 
+                        keyEncoder, 
+                        valueEncoder, 
+                        Json.Style.JETTISON_NATURAL).toString());
+    }
+
+    public void testTypeMapWithJsonStringDecode() {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("[1,2, 3]", "value");
+        AbstractJsonEncoderDecoder<String> keyEncoder = AbstractJsonEncoderDecoder.STRING;
+        AbstractJsonEncoderDecoder<String> valueEncoder = AbstractJsonEncoderDecoder.STRING;
+        assertEquals(map.toString(),
+                AbstractJsonEncoderDecoder.toMap(AbstractJsonEncoderDecoder.toJSON(map, keyEncoder, valueEncoder, Json.Style.DEFAULT),
+                        keyEncoder,
+                        valueEncoder,
+                        Json.Style.DEFAULT).toString());
+        assertEquals(map.toString(),
+                AbstractJsonEncoderDecoder.toMap(AbstractJsonEncoderDecoder.toJSON(map, keyEncoder, valueEncoder, Json.Style.JETTISON_NATURAL),
+                        keyEncoder,
+                        valueEncoder,
+                        Json.Style.JETTISON_NATURAL).toString());
+    }
+
     static class Email {
         String name, email;
         public String toString(){
@@ -491,9 +525,9 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
                         valueEncoder, 
                         Json.Style.DEFAULT).toString());
         assertEquals(map.toString(),
-                AbstractJsonEncoderDecoder.toMap(AbstractJsonEncoderDecoder.toJSON(map, keyEncoder, valueEncoder, Json.Style.JETTISON_NATURAL), 
-                        keyEncoder, 
-                        valueEncoder, 
+                AbstractJsonEncoderDecoder.toMap(AbstractJsonEncoderDecoder.toJSON(map, keyEncoder, valueEncoder, Json.Style.JETTISON_NATURAL),
+                        keyEncoder,
+                        valueEncoder,
                         Json.Style.JETTISON_NATURAL).toString());
     }
 
@@ -796,7 +830,7 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
     }
     static interface NestedBeanCodec extends JsonEncoderDecoder<NestedBean> {
     }
-    
+
     public void testBean() {
         BeanCodec beanCodec = GWT.create(BeanCodec.class);
         Bean bean = new Bean();


### PR DESCRIPTION
Hello,

We are using RestyGWT in our GWT application, and we faced with an issue with it.
Our system has quite long numbers as entity IDs. They work fine if we pass then as Strings or Lists of Strings, but they gets corrupted when you put them in Map.
Detailed description are in commit comments.
Could you please look at it?
