### PR TITLE
jaxrs-extension: handle Collections as Lists in QueryParams and in FormParms

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -170,6 +170,7 @@ public class RestServiceClassCreator extends BaseSourceCreator {
         this.OVERLAY_ARRAY_TYPES.add(find(JsArrayNumber.class, getLogger(), context));
         this.OVERLAY_ARRAY_TYPES.add(find(JsArrayString.class, getLogger(), context));
         this.QUERY_PARAM_LIST_TYPES = new HashSet<JClassType>();
+        this.QUERY_PARAM_LIST_TYPES.add(find(Collection.class, getLogger(), context));
         this.QUERY_PARAM_LIST_TYPES.add(find(List.class, getLogger(), context));
         this.QUERY_PARAM_LIST_TYPES.add(find(Set.class, getLogger(), context));
 		this.REST_SERVICE_TYPE = find(RestService.class, getLogger(), context);


### PR DESCRIPTION
This extends jaxrs standard a little bit but to a logical direction. CXF handles collections also as lists and I think RestyGWT should follow. This pull request continues the trend of f5e6a37 and c77005c
