### PR TITLE
Allow collections as keys in maps

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
@@ -301,7 +301,10 @@ public class JsonEncoderDecoderInstanceLocator {
             if( result != null ){
                 return JSON_NESTED_ENCODER_DECODER_CLASS + ".setEncoderDecoder( " + result + " )"; 
             }
-            return JSON_NESTED_ENCODER_DECODER_CLASS + ".collectionEncoderDecoder( " + result + " )";
+            result = isCollectionEncoderDecoder( clazz, types, style );
+            if ( result != null ){
+                return JSON_NESTED_ENCODER_DECODER_CLASS + ".collectionEncoderDecoder( " + result + " )";
+            }
         }
         result = isArrayEncoderDecoder(type, style);
         if( result != null ){


### PR DESCRIPTION
Allow keys of maps to be collections. Why we shouldn't? RestyGWT already allows arbitrary objects to be keys. So why not collections.
