### PR TITLE
Enums in @FormParams should not be enclosed in quotes

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -716,7 +716,7 @@ public class RestServiceClassCreator extends BaseSourceCreator {
                 OVERLAY_VALUE_TYPE.isAssignableFrom(type.isClass())) {
             return "(new " + JSON_OBJECT_CLASS + "(" + expr + ")).toString()";
         }
-        if (type.getQualifiedBinaryName().startsWith("java.lang.")) {
+        if (type.getQualifiedBinaryName().startsWith("java.lang.") || type.isEnum() != null) {
             return String.format("(%s != null ? %s.toString() : null)", expr, expr);
         }
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/FormParamTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/FormParamTestGwt.java
@@ -62,8 +62,16 @@ public class FormParamTestGwt extends GWTTestCase {
 
         @POST
         void arrayParams(@FormParam(value = "dtoArray") ExampleDto[] exampleDtoArray, MethodCallback<Echo> callback);
+
+        @POST
+        void enumParam(@FormParam("param") FormParamTestEnum param, MethodCallback<Echo> callback);
     }
-    
+
+    enum FormParamTestEnum {
+
+        VALUE
+    }
+
     class EchoMethodCallback implements MethodCallback<Echo> {
         
         private final String id;
@@ -205,6 +213,38 @@ public class FormParamTestGwt extends GWTTestCase {
         });
     }
 
+    public void testPostWithEnum() {
+        service.enumParam(FormParamTestEnum.VALUE, new MethodCallback<Echo>() {
+            @Override
+            public void onFailure(Method method, Throwable exception) {
+                fail();
+            }
+
+            @Override
+            public void onSuccess(Method method, Echo response) {
+                assertEquals(1, response.params.size());
+                assertEquals("VALUE", response.params.get("param"));
+
+                finishTest();
+            }
+        });
+    }
+
+    public void testPostWithNullEnum() {
+        service.enumParam(null, new MethodCallback<Echo>() {
+            @Override
+            public void onFailure(Method method, Throwable exception) {
+                fail();
+            }
+
+            @Override
+            public void onSuccess(Method method, Echo response) {
+                assertTrue(response.params.isEmpty());
+
+                finishTest();
+            }
+        });
+    }
 
     private List createDtoObjectAsList() {
         ArrayList result = new ArrayList();


### PR DESCRIPTION
Hello,

We encountered an issue with RestyGWT when using enums as FormParams.
RestyGWT encloses enum value in quotes, so payload looks like name=%22value%22 (x-www-form-urlencoded, so quotes turn into %22), instead of expected name=value.
The fix is to add special handling for enum, rather then serializing it as JSON.
