### PR TITLE
Update Jackson annotations to version 2.4 (fixes NoSuchMethodError in @JsonProperty with 2.4)

### DIFF
--- a/restygwt/src/main/java/com/fasterxml/jackson/annotation/JacksonAnnotationsInside.java
+++ b/restygwt/src/main/java/com/fasterxml/jackson/annotation/JacksonAnnotationsInside.java
@@ -5,9 +5,21 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ ElementType.ANNOTATION_TYPE })
+/**
+ * Meta-annotation (annotations used on other annotations)
+ * used for indicating that instead of using target annotation
+ * (annotation annotated with this annotation),
+ * Jackson should use meta-annotations it has.
+ * This can be useful in creating "combo-annotations" by having
+ * a container annotation, which needs to be annotated with this
+ * annotation as well as all annotations it 'contains'.
+ * 
+ * @since 2.0
+ */
+@Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @JacksonAnnotation
-public @interface JacksonAnnotationsInside {
+public @interface JacksonAnnotationsInside
+{
 
 }

--- a/restygwt/src/main/java/com/fasterxml/jackson/annotation/JsonProperty.java
+++ b/restygwt/src/main/java/com/fasterxml/jackson/annotation/JsonProperty.java
@@ -32,6 +32,15 @@ public @interface JsonProperty
     public final static String USE_DEFAULT_NAME = "";
 
     /**
+     * Marker value used to indicate that no index has been specified.
+     * Used as the default value as annotations do not allow "missing"
+     * values.
+     * 
+     * @since 2.4
+     */
+    public final static int INDEX_UNKNOWN = -1;
+    
+    /**
      * Defines name of the logical property, i.e. JSON object field
      * name to use for the property. If value is empty String (which is the
      * default), will try to use name of the field that is annotated.
@@ -59,6 +68,16 @@ public @interface JsonProperty
      */
     boolean required() default false;
 
+    /**
+     * Property that indicates numerical index of this property (relative
+     * to other properties specified for the Object). This index
+     * is typically used by binary formats, but may also be useful
+     * for schema languages and other tools.
+     * 
+     * @since 2.4
+     */
+    int index() default INDEX_UNKNOWN;
+    
     /* NOTE: considering of adding ability to specify default
      * String value -- would work well for scalar types, most of
      * which can coerce from Strings. But won't add for 2.0 yet.

--- a/restygwt/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/restygwt/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -198,15 +198,17 @@ public @interface JsonTypeInfo
      */
     
     /**
-     * What kind of type metadata is to be used for serializing and deserializing
-     * type information for instances of annotated type (and its subtypes
-     * unless overridden)
+     * Specifies kind of type metadata to use when serializing
+     * type information for instances of annotated type
+     * and its subtypes; as well as what is expected during
+     * deserialization.
      */
     public Id use();    
     
     /**
-     * What mechanism is used for including type metadata (if any; for
-     * {@link Id#NONE} nothing is included). Default
+     * Specifies mechanism to use for including type metadata (if any; for
+     * {@link Id#NONE} nothing is included); used when serializing,
+     * and expected when deserializing.
      *<p>
      * Note that for type metadata type of {@link Id#CUSTOM},
      * this setting may or may not have any effect.
@@ -221,16 +223,17 @@ public @interface JsonTypeInfo
      * is only used for determining actual type.
      *<p>
      * Default property name used if this property is not explicitly defined
-     * (or is set to empty String) is based on
+     * (or is set to empty <code>String</code>) is based on
      * type metadata type ({@link #use}) used.
      */
     public String property() default "";
 
     /**
      * Optional property that can be used to specify default implementation
-     * class to use if type identifier is either not present, or can not
-     * be mapped to a registered type (which can occur for ids, but not when
-     * specifying explicit class to use).
+     * class to use for deserialization if type identifier is either not present,
+     * or can not be mapped to a registered type (which can occur for ids,
+     * but not when specifying explicit class to use).
+     * Property has no effect on serialization.
      *<p>
      * Note that while this property allows specification of the default
      * implementation to use, it does not help with structural issues that
@@ -246,6 +249,8 @@ public @interface JsonTypeInfo
      * <li><code>com.fasterxml.jackson.databind.annotation.NoClass</code> means that
      *   objects with unmappable (or missing) type are to be mapped to null references.
      * </ul>
+     * 
+     * TODO: In 2.5, change default to {@link java.lang.Void}
      */
     public Class<?> defaultImpl() default None.class;
 
@@ -253,6 +258,7 @@ public @interface JsonTypeInfo
      * Property that defines whether type identifier value will be passed
      * as part of JSON stream to deserializer (true), or handled and
      * removed by <code>TypeDeserializer</code> (false).
+     * Property has no effect on serialization.
      *<p>
      * Default value is false, meaning that Jackson handles and removes
      * the type identifier from JSON content that is passed to
@@ -272,6 +278,9 @@ public @interface JsonTypeInfo
      * This marker class that is only to be used with <code>defaultImpl</code>
      * annotation property, to indicate that there is no default implementation
      * specified.
+     * 
+     * @deprecated Since 2.4, use {@link java.lang.Void} instead.
      */
+    @Deprecated
     public abstract static class None { }
 }


### PR DESCRIPTION
When using RestyGWT 2.0-SNAPSHOT with Jackson 2.4, if RestyGWT is first on the classpath, Jackson fails with:

```
java.lang.NoSuchMethodError: com.fasterxml.jackson.annotation.JsonProperty.index()I
```

This commit fixes the issue by updating annotations to those from Jackson 2.4, adding the missing `index()` method to `@JsonProperty`. 
