### PR TITLE
added unit test to EncoderDecoderTestGwt which demonstrates a problem wi...

### DIFF
--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import javax.validation.constraints.AssertTrue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
@@ -1213,6 +1214,7 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
     }
     
     static interface JsonSubTypesWithAnInterfaceCodec extends JsonEncoderDecoder<JsonSubTypesWithAnInterface> {}
+    static interface JsonSubTypesWithAnInterfaceImplementationCodec extends JsonEncoderDecoder<DefaultImplementationOfSubTypeInterface> {}
 
     public void testJsonSubTypesWithAnInterface() {
         JsonSubTypesWithAnInterfaceCodec codec = GWT.create(JsonSubTypesWithAnInterfaceCodec.class);
@@ -1227,6 +1229,21 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         assertEquals(value, o1.getValue());
         assertEquals(o1.getValue(), o2.getValue());
         assertEquals(o2.getClass(), DefaultImplementationOfSubTypeInterface.class);
+    }
+
+    public void testJsonSubTypesWithInterfaceUsingConcreteImplementationCodec() {
+        JsonSubTypesWithAnInterfaceImplementationCodec codec = GWT.create(JsonSubTypesWithAnInterfaceImplementationCodec.class);
+        String value = "Hello, world!";
+        DefaultImplementationOfSubTypeInterface o1 = new DefaultImplementationOfSubTypeInterface(value);
+
+        JSONValue json = codec.encode(o1);
+        JSONValue objectClass = json.isObject().get("@class");
+        assertNotNull(objectClass);
+        assertEquals(objectClass.isString().stringValue(),
+                DefaultImplementationOfSubTypeInterface.class.getName().replace("$","."));
+        DefaultImplementationOfSubTypeInterface o2 = codec.decode(json);
+        assertEquals(json.toString(), codec.encode(o2).toString());
+        assertEquals(value, o1.getValue());
     }
     
 
@@ -1250,4 +1267,5 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         JsonSubTypesWithAnInterfaceForUseWithAnEnum useWithAnEnum = codec.decode(json);
         assertEquals(useWithAnEnum.name(), EnumOfSubTypeInterface.HELLO.name());
     }
+
 }


### PR DESCRIPTION
Added unit test "testJsonSubTypesWithInterfaceUsingConcreteImplementationCodec" to EncoderDecoderTestGwt which fails at the moment because of a problem with missing @class attribute in json when using an encoder of a concrete implementation instead of a super class. This leads to exceptions when decoding the created json to java object with jackson 2.3.2 on server side in a spring mvc controller.

In fact this is a problem if you have a RestService for the concrete subclass and a corresponding spring mvc controller on server side.

According to implementation of jackson 2.3.x the @class attribute should be added ever, when any of the super classes has a @JsonTypeInfo and @JsonSubTypes annotation.

Tried to fix it myself yesterday, but i am not familiar enough with GWT Generators and the resty gwt codebase to figure out were to put this in.
