### PR TITLE
JavaSourceCategory is no longer public

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestBaseSourceCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestBaseSourceCreator.java
@@ -32,7 +32,7 @@ public abstract class DirectRestBaseSourceCreator extends BaseSourceCreator {
         super(logger, context, source, suffix);
     }
 
-    protected ClassSourceFileComposerFactory createClassSourceComposerFactory(ClassSourceFileComposerFactory.JavaSourceCategory createWhat,
+    protected ClassSourceFileComposerFactory createClassSourceComposerFactory(JavaSourceCategory createWhat,
                                                                             String [] annotationDeclarations,
                                                                             String [] extendedInterfaces) {
         String genericTypeParameters = createClassDeclarationGenericType();
@@ -42,7 +42,7 @@ public abstract class DirectRestBaseSourceCreator extends BaseSourceCreator {
                 shortName + genericTypeParameters
         );
 
-        if (createWhat == ClassSourceFileComposerFactory.JavaSourceCategory.INTERFACE) {
+        if (createWhat == JavaSourceCategory.INTERFACE) {
             composerFactory.makeInterface();
         }
 

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
@@ -14,7 +14,6 @@ import org.fusesource.restygwt.client.RestServiceProxy;
 import org.fusesource.restygwt.client.callback.CallbackAware;
 import org.fusesource.restygwt.rebind.util.OnceFirstIterator;
 
-import static com.google.gwt.user.rebind.ClassSourceFileComposerFactory.JavaSourceCategory;
 import static org.fusesource.restygwt.rebind.DirectRestServiceInterfaceClassCreator.DIRECT_REST_SERVICE_SUFFIX;
 
 public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
@@ -27,7 +26,7 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
 
     @Override
     protected ClassSourceFileComposerFactory createComposerFactory() throws UnableToCompleteException {
-        return createClassSourceComposerFactory( JavaSourceCategory.CLASS,
+        return createClassSourceComposerFactory(JavaSourceCategory.CLASS,
                 null,
                 new String[]{
                         source.getParameterizedQualifiedSourceName(),

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
@@ -30,7 +30,6 @@ import org.fusesource.restygwt.rebind.util.OnceFirstIterator;
 
 import java.lang.annotation.Annotation;
 
-import static com.google.gwt.user.rebind.ClassSourceFileComposerFactory.JavaSourceCategory;
 import static org.fusesource.restygwt.rebind.DirectRestServiceClassCreator.isVoidMethod;
 
 /**

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JavaSourceCategory.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JavaSourceCategory.java
@@ -1,0 +1,5 @@
+package org.fusesource.restygwt.rebind;
+
+public enum JavaSourceCategory {
+    INTERFACE, CLASS
+}


### PR DESCRIPTION
In GWT 7.0 com.google.gwt.user.rebind.ClassSourceFileComposerFactory.JavaSourceCategory seems to be no longer public, so I added the Enum to resty-gwt in order to use it with GWT 7.0-rc1.

https://github.com/gwtproject/gwt/commit/e2154f39479e29dfd50ea27dc79ddaec782bdb90
