### PR TITLE
fixing issue with IE sending "undefined" in the request body that was supposed to be empty

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
@@ -64,7 +64,10 @@ public class Method {
         public MethodRequestBuilder(String method, String url) {
 
             super(method, url);
-
+            //without null value being explicitly set gwt would generate "undefined" as a default value,
+            //so if request does not have a body, Internet Explorer would send string "undefined" in the body of POST, PUT and DELETE requests,
+            //which may cause the request to fall on server with "No operation matching request path"
+            setRequestData(null);
             setHeader("X-HTTP-Method-Override", method);
         }
     }


### PR DESCRIPTION
I've faced the same issue with IE and Resty GWT as it described here: https://github.com/ArcBees/GWTP/issues/584. IE11 (well, that is the only IE I have) sends "undefined" string in the request's body in case of POST, PUT or DELETE request with no body (Chrome and Firefox both send nothing). That "undefined" request fails with a meaningless warning like: 

> [2014-11-24 13:06:50,852] [ajp-bio-8039-exec-2] WARN  org.apache.cxf.jaxrs.utils.JAXRSUtils [] - No operation matching request path "/my/perfectly/correctPath" is found, Relative Path: /correctPath, HTTP Method: PUT, ContentType: text/plain;charset=UTF-8, Accept: application/json,. Please enable FINE/TRACE log level for more details.

This patch fixes the issue (at least for IE11).
