### PR TITLE
Fix GWT 2.7 incremental super dev mode when using RestyJsonTypeIdResolver

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -645,6 +645,10 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
         }
     }
 
+    static public void clearRestyResolverClassMap() {
+    	sTypeIdResolverMap = null;
+    }
+    
     public static Map<Class<?>, RestyJsonTypeIdResolver> getRestyResolverClassMap(GeneratorContext context, TreeLogger logger) throws UnableToCompleteException {
 	if (sTypeIdResolverMap == null) {
 	    try {

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceGenerator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceGenerator.java
@@ -35,10 +35,10 @@ public class RestServiceGenerator extends Generator {
         try {
             JClassType restService = find(logger, context, source);
             RestServiceClassCreator generator = new RestServiceClassCreator(logger, context, restService);
-
             return generator.create();
         } finally {
             BaseSourceCreator.clearGeneratedClasses();
+            JsonEncoderDecoderClassCreator.clearRestyResolverClassMap();
         }
     }
 


### PR DESCRIPTION
This clear the cached RestyJsonTypeIdResolver after regeneration of code. Prevents stale types from being held onto.