### PR TITLE
Fix bug: Checking value.getClass().isAnnotation() does not always work. ...

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/util/AnnotationCopyUtil.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/util/AnnotationCopyUtil.java
@@ -79,7 +79,7 @@ public class AnnotationCopyUtil {
             return "null";
         } else if (value.getClass().isArray()) {
             return readArrayValue(value);
-        } else if (value.getClass().isAnnotation()) {
+        } else if (value instanceof Annotation) {
             return getAnnotationAsString((Annotation) value);
         } else if (value instanceof Boolean) {
             return readBooleanValue((Boolean) value);
@@ -87,7 +87,7 @@ public class AnnotationCopyUtil {
             return readClassValue((Class) value);
         }
 
-        return null;
+        throw new RuntimeException("Unsupported value for encodeAnnotationValue: " + value);
     }
 
     private static String readBooleanValue(Boolean value) {


### PR DESCRIPTION
...Use (value instanceof Annotation) instead.

It seems that an annotation that is part of a complex annotation does not return true for isAnnotation().
Using instanceof Annotation fixes the problem.

This also gets rid of the silent failure for unknown annotation value types.