### PR TITLE
Adds support for regex in URI templates

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -375,7 +375,7 @@ public class RestServiceClassCreator extends BaseSourceCreator {
 
     private String pathExpression(String pathExpression, JParameter arg, PathParam paramPath) {
         String expr = toStringExpression(arg);
-        return pathExpression.replaceAll(Pattern.quote("{" + paramPath.value() + "}"),
+        return pathExpression.replaceAll(Pattern.quote("{" + paramPath.value()) + "(\\s*:\\s*(.)+)?\\}",
                "\"+(" + expr + "== null? null : ((\"\" + " + expr +").startsWith(\"http\") ? " + expr +
                " : com.google.gwt.http.client.URL.encodePathSegment(" + expr + ")))+\"");
     }

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PathParamTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PathParamTestGwt.java
@@ -60,6 +60,9 @@ public class PathParamTestGwt extends GWTTestCase {
         @Path("/get/{id}")
         void get(@PathParam(value = "id") String i, MethodCallback<Echo> callback);
 
+        @GET @Path("/get/{id : \\d+}")
+        void getRegex(@PathParam(value = "id") Integer i, MethodCallback<Echo> callback);
+
         @GET @Path("{url}")
         void absolute(@PathParam(value = "url") String u, MethodCallback<Echo> callback);
     }
@@ -129,6 +132,11 @@ public class PathParamTestGwt extends GWTTestCase {
         service.get(123, echoMethodCallback("/get/123"));
         delayTestFinish(10000);
 
+    }
+
+    public void testGetWithIntRegex() {
+        service.getRegex(123, echoMethodCallback("/get/123"));
+        delayTestFinish(10000);
     }
 
     public void testAbsolute() {


### PR DESCRIPTION
To be more precise, it allows them not to fail. There's no verification
of the regular expression against the value that is passed.

This allows one to use regular expressions in URI templates for other
clients of the API.

I added a test with regex to validate the PR.