### PR TITLE
Add test for inner DirectRestService interface, and fix

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
@@ -98,7 +98,7 @@ public abstract class BaseSourceCreator extends AbstractSourceCreator {
         this.name = packageName + "." + shortName;
     }
 
-    private String getName( JClassType source ){
+    protected String getName( JClassType source ){
         if( source.getEnclosingType() != null ){
             return getName( source.getEnclosingType() ) + "_" + source.getSimpleSourceName();
         }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
@@ -45,8 +45,8 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
     }
 
     private void createRestyServiceField() {
-        p("private " + source.getName() + DIRECT_REST_SERVICE_SUFFIX + " service = com.google.gwt.core.client.GWT.create(" +
-                source.getName() + DIRECT_REST_SERVICE_SUFFIX + ".class);");
+        String sourceName = getName(source) + DIRECT_REST_SERVICE_SUFFIX;
+        p("private " + sourceName + " service = com.google.gwt.core.client.GWT.create(" + sourceName + ".class);");
     }
 
     private void createDelegateRestServiceProxyMethods() {

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
@@ -24,6 +24,9 @@ import org.fusesource.restygwt.client.*;
 
 import java.util.List;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
 /**
  * @author <a href="mailto:bogdan.mustiata@gmail.com">Bogdan Mustiata</<a>
  */
@@ -31,6 +34,11 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
     @Override
     public String getModuleName() {
         return "org.fusesource.restygwt.DirectRestServiceTestGwt";
+    }
+
+    static interface InnerDirectRestService extends DirectRestService {
+        @GET @Path("/something")
+        void getSomething();
     }
 
     public void testCallingMethodsDirectlyShouldFail() {
@@ -85,4 +93,10 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
             }
         }).call(directExampleService).storeDto(new ExampleDto());
     }
+
+    public void testInnerInterface() {
+        InnerDirectRestService innerDirectService = GWT.create(InnerDirectRestService.class);
+        assertNotNull(innerDirectService);
+    }
+
 }


### PR DESCRIPTION
Using inner DirectRestService interface cause a RuntimeException

java.lang.RuntimeException: Deferred binding failed for 'org.fusesource.restygwt.client.basic.DirectRestServiceTestGwt$InnerDirectRestService' (did you forget to inherit a required module?)