### PR TITLE
janitorial: remove obvious eclipse warning and a typo

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -342,13 +342,12 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
             
             if (Defaults.getTimeZone() == null || Defaults.dateFormatHasTimeZone()) {
                 return DateTimeFormat.getFormat(format).parse(str.stringValue());
-            } else {
-                // We need to provide time zone information to the GWT date parser.
-                // Unfortunately, DateTimeFormat has no overload specifying a TimeZone,
-                // so the only way is to extend the format string.
-                return DateTimeFormat.getFormat(format + " v").parse(
-                        str.stringValue() + " " + Defaults.getTimeZone().getID());
             }
+            // We need to provide time zone information to the GWT date parser.
+            // Unfortunately, DateTimeFormat has no overload specifying a TimeZone,
+            // so the only way is to extend the format string.
+            return DateTimeFormat.getFormat(format + " v").parse(
+                    str.stringValue() + " " + Defaults.getTimeZone().getID());
         }
 
         @Override
@@ -365,9 +364,8 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
             
             if (Defaults.getTimeZone() == null || Defaults.dateFormatHasTimeZone()) {
                 return new JSONString(DateTimeFormat.getFormat(format).format(value));
-            } else {
-                return new JSONString(DateTimeFormat.getFormat(format).format(value, Defaults.getTimeZone()));
             }
+            return new JSONString(DateTimeFormat.getFormat(format).format(value, Defaults.getTimeZone()));
         }
     };
 
@@ -529,15 +527,13 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         if (value.isString() != null) {
            return Base64Codec.decode(value.isString().stringValue());
         }
-        else {
-            JSONArray array = asArray(value);
-            int size = array.size();
-            byte template[] = new byte[size];
-            for (int i = 0; i < size; i++) {
-                template[i] = encoder.decode(array.get(i));
-            }
-            return template;
+        JSONArray array = asArray(value);
+        int size = array.size();
+        byte template[] = new byte[size];
+        for (int i = 0; i < size; i++) {
+            template[i] = encoder.decode(array.get(i));
         }
+        return template;
     }
 
     static public char[] toArray(JSONValue value, AbstractJsonEncoderDecoder<Character> encoder, char[] template) {
@@ -895,14 +891,12 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         if (Defaults.isByteArraysToBase64()) {
            return new JSONString(Base64Codec.encode(value));
         }
-        else {
-            JSONArray rc = new JSONArray();
-            int i = 0;
-            for (byte t : value) {
-                rc.set(i++, new JSONNumber(t));
-            }
-            return rc;
+        JSONArray rc = new JSONArray();
+        int i = 0;
+        for (byte t : value) {
+            rc.set(i++, new JSONNumber(t));
         }
+        return rc;
     }
 
     static private JSONNull getNullType() {

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/dispatcher/DefaultFilterawareDispatcher.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/dispatcher/DefaultFilterawareDispatcher.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import org.fusesource.restygwt.client.Method;
-import org.fusesource.restygwt.client.cache.QueueableCacheStorage;
-import org.fusesource.restygwt.client.callback.DefaultFilterawareRequestCallback;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.Request;

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
@@ -122,7 +122,7 @@ public abstract class BaseSourceCreator extends AbstractSourceCreator {
       return name;
     }
     
-    protected PrintWriter writer() throws UnableToCompleteException {
+    protected PrintWriter writer() {
         HashSet<String> classes = getGeneratedClasses();
         if (classes.contains(name)) {
             return null;

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -153,16 +153,14 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
     private Collection<Type> findJsonSubTypes(JClassType clazz) {
         if (clazz == null)
             return Collections.emptyList();
-        else {
-            JsonSubTypes annotation = getClassAnnotation(clazz, JsonSubTypes.class);
-            if (annotation == null) {
-                return Collections.emptyList();
-            }
-            Set<Type> result = new HashSet<JsonSubTypes.Type>();
-            Type[] value = annotation.value();
-            Collections.addAll(result, value);
-            return result;
+        JsonSubTypes annotation = getClassAnnotation(clazz, JsonSubTypes.class);
+        if (annotation == null) {
+            return Collections.emptyList();
         }
+        Set<Type> result = new HashSet<JsonSubTypes.Type>();
+        Type[] value = annotation.value();
+        Collections.addAll(result, value);
+        return result;
     }
 
     protected void generateSingleton(String shortName)
@@ -219,7 +217,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                     generateEnumEncodeMethodBody(possibleType, typeInfo);
                 } else {
 
-                    // Try to find a constuctor that is annotated as creator
+                    // Try to find a constructor that is annotated as creator
                     final JConstructor creator = findCreator(possibleType.clazz);
 
                     List<JField> orderedFields = creator == null ? null : getOrderedFields(getFields(possibleType.clazz), creator);


### PR DESCRIPTION
This removes 8 warnings in my eclipse.
   5 unnecessary else nesting
   2 unnecessary exception
   1 exception is not thrown

and one small typo