### PR TITLE
Fix for issue #249

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -451,8 +451,13 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                         }
                         p("object = toObjectFromWrapper(value, \"" + possibleType.tag + "\");");
                     } else if (!isLeaf) {
-                        p("if(sourceName.equals(\"" + possibleType.tag + "\"))");
-                        p("{");
+                        if (classType.equals(possibleType.clazz)) {
+                            p("if(sourceName == null || sourceName.equals(\"" + possibleType.tag + "\"))");
+                            p("{");
+                        } else {
+                            p("if(sourceName != null && sourceName.equals(\"" + possibleType.tag + "\"))");
+                            p("{");
+                        }
                     }
                 }
 


### PR DESCRIPTION
The problem is described at https://github.com/resty-gwt/resty-gwt/issues/249
This fix is that by default if sourceName is null, we will use the decoding based on the classtype that we are generating the JsonEncocderDecoderClass for