### PR TITLE
Fix Defaults.ignoreJsonNulls() for enums values, also improves generated code size

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -905,9 +905,9 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         }
     }
 
-    static protected void isNotNullValuePut(Object object, JSONObject value, String jsonName) {
+    static protected void isNotNullValuePut(JSONValue object, JSONObject value, String jsonName) {
     	if(object != null)
-    		value.put(jsonName, value);
+    		value.put(jsonName, object);
     }
     
     static protected boolean isNotNullAndCheckDefaults(Object object, JSONObject value, String jsonName) {

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -905,6 +905,17 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         }
     }
 
+    static protected boolean isNotNullAndCheckDefaults(Object object, JSONObject value, String jsonName) {
+    	if(object != null)
+    		return true;
+    	else if(Defaults.doesIgnoreJsonNulls())
+    		return false;
+    	else {
+    		value.put(jsonName, JSONNull.getInstance());
+    		return false;
+    	}
+    }
+    
     static private JSONNull getNullType() {
         return (Defaults.doesIgnoreJsonNulls()) ? null : JSONNull.getInstance();
     }

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -905,6 +905,11 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         }
     }
 
+    static protected void isNotNullValuePut(Object object, JSONObject value, String jsonName) {
+    	if(object != null)
+    		value.put(jsonName, value);
+    }
+    
     static protected boolean isNotNullAndCheckDefaults(Object object, JSONObject value, String jsonName) {
     	if(object != null)
     		return true;

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -317,7 +317,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
 
                                         p(JSON_VALUE_CLASS + " v=" + expression + ";");
                                         
-                                        p("isNotNullValuePut(" + fieldExpr+ ", rc, "+ wrap(jsonName) + ");");
+                                        p("isNotNullValuePut(" + expression + ", rc, "+ wrap(jsonName) + ");");
 
                                         if (null != field.getType().isEnum()) {
                                             i(-1).p("}");

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -316,11 +316,8 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                                         }
 
                                         p(JSON_VALUE_CLASS + " v=" + expression + ";");
-                                        p("if( v!=null ) {").i(1);
-                                        {
-                                            p("rc.put(" + wrap(jsonName) + ", v);");
-                                        }
-                                        i(-1).p("}");
+                                        
+                                        p("isNotNullValuePut(" + fieldExpr+ ", rc, "+ wrap(jsonName) + ");");
 
                                         if (null != field.getType().isEnum()) {
                                             i(-1).p("}");

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -312,9 +312,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                                     p("{").i(1);
                                     {
                                         if (null != field.getType().isEnum()) {
-                                            p("if(" + fieldExpr + " == null) {").i(1);
-                                            p("rc.put(" + wrap(jsonName) + ", " + JSON_NULL_CLASS + ".getInstance());");
-                                            i(-1).p("} else {").i(1);
+                                            p("if(isNotNullAndCheckDefaults(" + fieldExpr+ ", rc, "+ wrap(jsonName) + ")) {").i(1);
                                         }
 
                                         p(JSON_VALUE_CLASS + " v=" + expression + ";");

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -309,20 +309,17 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                                     Style style = jsonAnnotation != null ? jsonAnnotation.style() : classStyle;
                                     String expression = locator.encodeExpression(field.getType(), fieldExpr, style);
 
-                                    p("{").i(1);
-                                    {
-                                        if (null != field.getType().isEnum()) {
-                                            p("if(isNotNullAndCheckDefaults(" + fieldExpr+ ", rc, "+ wrap(jsonName) + ")) {").i(1);
-                                        }
-                                        
-                                        p("isNotNullValuePut(" + expression + ", rc, "+ wrap(jsonName) + ");");
-
-                                        if (null != field.getType().isEnum()) {
-                                            i(-1).p("}");
-                                        }
-
+                                    
+                                    if (null != field.getType().isEnum()) {
+                                    	p("if(isNotNullAndCheckDefaults(" + fieldExpr+ ", rc, "+ wrap(jsonName) + ")) {").i(1);
                                     }
-                                    i(-1).p("}");
+                                        
+                                    p("isNotNullValuePut(" + expression + ", rc, "+ wrap(jsonName) + ");");
+
+                                    if (null != field.getType().isEnum()) {
+                                    	i(-1).p("}");
+                                    }
+                                    
 
                                 } else {
                                     getLogger().log(DEBUG, "private field gets ignored: " + field.getEnclosingType().getQualifiedSourceName() + "." + field.getName());

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -314,8 +314,6 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                                         if (null != field.getType().isEnum()) {
                                             p("if(isNotNullAndCheckDefaults(" + fieldExpr+ ", rc, "+ wrap(jsonName) + ")) {").i(1);
                                         }
-
-                                        p(JSON_VALUE_CLASS + " v=" + expression + ";");
                                         
                                         p("isNotNullValuePut(" + expression + ", rc, "+ wrap(jsonName) + ");");
 


### PR DESCRIPTION
Now when the value is set in Defaults, null enums will be left out of
the request.
This change also reduces the size of the generated code. Rather than
doing if/else, we now have a one line if statement call to the new
method (isNotNullAndCheckDefaults) to check defaults, and if null should
be included or not.