### PR TITLE
Reduce generated code size for Decode methods.

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -905,14 +905,14 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         }
     }
 
-    static protected short getValueToSetForShort(Short value, int defaultValue, boolean needsNullHandling){
+    static protected short getValueToSetForShort(Short value, int defaultValue){
     	if(value == null)
     		return (short)defaultValue;
     	else 
     		return value;
     }
     
-    static protected <T extends Object> T getValueToSet(T value, T defaultValue, boolean needsNullHandling) {
+    static protected <T extends Object> T getValueToSet(T value, T defaultValue) {
     	if(value instanceof JSONNull || value == null)
     		return defaultValue;
     	else 

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -905,6 +905,20 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         }
     }
 
+    static protected short getValueToSetForShort(Short value, int defaultValue, boolean needsNullHandling){
+    	if(value == null)
+    		return (short)defaultValue;
+    	else 
+    		return value;
+    }
+    
+    static protected <T extends Object> T getValueToSet(T value, T defaultValue, boolean needsNullHandling) {
+    	if(value instanceof JSONNull || value == null)
+    		return defaultValue;
+    	else 
+    		return value;
+    }
+    
     static protected void isNotNullValuePut(JSONValue object, JSONObject value, String jsonName) {
     	if(object != null)
     		value.put(jsonName, object);

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -543,17 +543,15 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                                     String objectGetter = "object.get(" + wrap(jsonName) + ")";
                                     String expression = locator.decodeExpression(field.getType(), objectGetter, style);
 
-                                    boolean needNullHandling = !locator.hasCustomEncoderDecoder(field.getType());
-
                                     boolean isShort = field.getType().isPrimitive() == JPrimitiveType.SHORT;
                                     String defaultValue = getDefaultValue(field);
 
                                     String methodName = isShort ? "getValueToSetForShort" : "getValueToSet";
                                     
                                     if (setterName != null) {
-                                    	p("rc." + setterName + "("  + methodName + "(" + expression + ", " + defaultValue + "," + needNullHandling + "));");
+                                    	p("rc." + setterName + "("  + methodName + "(" + expression + ", " + defaultValue + "));");
                                     } else {
-                                    	p("rc." + name + "= " +  methodName + "(" + expression + "," + defaultValue + "," + needNullHandling+ ");");
+                                    	p("rc." + name + "= " +  methodName + "(" + expression + "," + defaultValue + ");");
                                     }
                                     
                                 } else {


### PR DESCRIPTION
Refactor decode method generation for fields, 7 lines merged into one,
using new methods on AbstractJsonEncoderDecoder

Example:

This old generated code:
```
if(object.get("cashAmount") != null) {
      if(object.get("cashAmount") instanceof com.google.gwt.json.client.JSONNull) {
        rc.setCashAmount(null);
      } else {
    rc.setCashAmount(org.fusesource.restygwt.client.AbstractJsonEncoderDecoder.BIG_DECIMAL.decode(object.get("cashAmount")));
      }
    }
```

becomes just this one line:

 ```
rc.setCashAmount(getValueToSet(org.fusesource.restygwt.client.AbstractJsonEncoderDecoder.BIG_DECIMAL.decode(object.get("cashAmount")), 0L,true));
```