### PR TITLE
fix for NullPointerException on sending null object

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -934,8 +934,8 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
     		return false;
     	}
     }
-    
-    static private JSONNull getNullType() {
+
+    static protected JSONNull getNullType() {
         return (Defaults.doesIgnoreJsonNulls()) ? null : JSONNull.getInstance();
     }
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -202,7 +202,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
         {
             p("if( value==null ) {").i(1);
             {
-                p("return null;");
+                p("return getNullType();");
             }
             i(-1).p("}");
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/GwtCompleteTestSuite.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/GwtCompleteTestSuite.java
@@ -22,6 +22,7 @@ package org.fusesource.restygwt;
 import junit.framework.Test;
 import junit.framework.TestCase;
 
+import org.fusesource.restygwt.client.basic.BasicTestGwt;
 import org.fusesource.restygwt.client.basic.CacheCallbackTestGwt;
 import org.fusesource.restygwt.client.basic.CachingTestGwt;
 import org.fusesource.restygwt.client.basic.ConfiguredServiceTestGwt;
@@ -74,6 +75,7 @@ public class GwtCompleteTestSuite extends TestCase {
     public static Test suite() {
         GWTTestSuite suite = new GWTTestSuite("all GwtTestCases but AnnotationResolver" );
 
+        suite.addTestSuite(BasicTestGwt.class);
         // keep the cache-callback at the beginning to get it pass
         // TODO why ? and what goes wrong when at located at the end ?
         suite.addTestSuite(CacheCallbackTestGwt.class);

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/BasicTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/BasicTestGwt.java
@@ -21,8 +21,7 @@ package org.fusesource.restygwt.client.basic;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.junit.client.GWTTestCase;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import com.google.gwt.user.client.Timer;
 
 import org.fusesource.restygwt.client.Method;
 import org.fusesource.restygwt.client.MethodCallback;
@@ -89,8 +88,16 @@ public class BasicTestGwt extends GWTTestCase {
 
         request.cancel();
 
+        // after waiting for 10 seconds assume, that the request has been canceled successfully
+        new Timer() {
+            @Override
+            public void run() {
+                finishTest();
+            }
+        }.schedule(10000);
+        
         // wait... we are in async testing...
-        delayTestFinish(10000);
+        delayTestFinish(15000);
     }
 
     @Test

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/BasicTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/BasicTestGwt.java
@@ -44,10 +44,8 @@ public class BasicTestGwt extends GWTTestCase {
     }
 
     public void testDefaultFunction() {
-
         //configure RESTY
         Resource resource = new Resource(GWT.getModuleBaseURL() + "api/getendpoint");
-
 
         ExampleService service = GWT.create(ExampleService.class);
         ((RestServiceProxy) service).setResource(resource);
@@ -56,36 +54,28 @@ public class BasicTestGwt extends GWTTestCase {
 
             @Override
             public void onSuccess(Method method, ExampleDto response) {
-
                 assertEquals(response.name, "myName");
                 finishTest();
-
             }
 
             @Override
             public void onFailure(Method method, Throwable exception) {
                 fail();
-
             }
         });
 
         // wait... we are in async testing...
         delayTestFinish(10000);
-
     }
-    
+
     @Test
     public void testCancelRequest() {
-
-        //configure RESTY
         Resource resource = new Resource(GWT.getModuleBaseURL() + "api/getendpoint");
-
 
         ExampleService service = GWT.create(ExampleService.class);
         ((RestServiceProxy) service).setResource(resource);
 
         Request request = service.getExampleDtoCancelable(new MethodCallback<ExampleDto>() {
-
             @Override
             public void onSuccess(Method method, ExampleDto response) {
                 fail();
@@ -98,8 +88,34 @@ public class BasicTestGwt extends GWTTestCase {
         });
 
         request.cancel();
-        
+
         // wait... we are in async testing...
         delayTestFinish(10000);
     }
+
+    @Test
+    public void testNullObjectPost() {
+        //configure RESTY
+        Resource resource = new Resource(GWT.getModuleBaseURL() + "api");
+
+        ExampleService service = GWT.create(ExampleService.class);
+        ((RestServiceProxy) service).setResource(resource);
+
+        service.storeDto(null, new MethodCallback<Void>() {
+            @Override
+            public void onSuccess(Method method, Void response) {
+                // Nothing awaited because its a test for send null objects
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable exception) {
+                fail();
+            }
+        });
+
+        // wait... we are in async testing...
+        delayTestFinish(10000);
+    }
+
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/ExampleService.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/ExampleService.java
@@ -23,6 +23,8 @@ import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.RestService;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 
 /**
  * Supersimple example service for testing...
@@ -32,11 +34,15 @@ import javax.ws.rs.GET;
 public interface ExampleService extends RestService {
     @GET
     public void getExampleDto(MethodCallback<ExampleDto> callback);
-    
+
     /**
      * Used to make sure the generator handles Request result. 
      * It can be used to cancel requests.
      */
     @GET
     public Request getExampleDtoCancelable(MethodCallback<ExampleDto> callback);
+
+    @POST
+    @Path("/store")
+    void storeDto(ExampleDto exampleDto, MethodCallback<Void> callback);
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/mocking/MockedTest.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/mocking/MockedTest.java
@@ -62,6 +62,10 @@ public class MockedTest extends TestCase {
                 callback.onSuccess(null, exampleDto);
                 return null;
             }
+            @Override
+            public void storeDto(ExampleDto exampleDto, MethodCallback<Void> callback) {
+                callback.onSuccess(null, null);
+            }
         };
 
         /** test*/
@@ -78,6 +82,5 @@ public class MockedTest extends TestCase {
         });
 
     }
-
 
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/basic/BasicTestGwtServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/basic/BasicTestGwtServlet.java
@@ -38,15 +38,18 @@ public class BasicTestGwtServlet extends HttpServlet {
 
     private static final String DUMMY_RESPONSE = "{\"name\":\"myName\"}";
 
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.getWriter().print(DUMMY_RESPONSE);
+    }
 
     @Override
-    protected void doGet(HttpServletRequest request,
-            HttpServletResponse response) throws IOException {
-
-
-            response.getWriter().print(DUMMY_RESPONSE);
-
-
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (request.getRequestURI().endsWith("/api/store")) {
+            response.getWriter().print("");
+        } else {
+            throw new IllegalArgumentException("Invalid servlet path called by service: " + request.getRequestURI());
+        }
     }
 
 }


### PR DESCRIPTION
* fixes NullPointerException in Method.json for data.toString() because generated JsonEncoderDecoder return null, instead of JSONNull, for null objects.
* add BasicTestGwt to testsuit
 * finish cancel testcase successfully after 10 seconds without response (no onSuccess/onFailure call)