### PR TITLE
Created FailedResponseException which contains the Response instance

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/ExceptionMapper.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/ExceptionMapper.java
@@ -30,6 +30,6 @@ public class ExceptionMapper {
      * @return the exception to be passed to the callback
      */
     public Throwable createFailedStatusException(Method method, Response response) {
-        return new FailedStatusCodeException(response.getStatusText(), response.getStatusCode());
+        return new FailedResponseException(response);
     }
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/FailedResponseException.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/FailedResponseException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.client;
+
+import com.google.gwt.http.client.Response;
+
+public class FailedResponseException extends FailedStatusCodeException {
+    private final Response response;
+
+    public FailedResponseException(Response response) {
+        super(response.getStatusText(), response.getStatusCode());
+        this.response = response;
+    }
+
+    public Response getResponse() {
+        return response;
+    }
+}


### PR DESCRIPTION
Usually response text or header contains useful information about the server failure cause. I initially just added the response text which is the actual requirement for my project, later I think that the header might be useful too. And finally, I just added the response instance which looks like a good idea so Failed**Response**Exception contains a Response :smile:.