### PR TITLE
Fix for Jersy server array with 1 element and for turn off the 'X-HTTP-Method-Override' header.

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -422,7 +422,12 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
     static JSONArray asArray(JSONValue value) {
         JSONArray array = value.isArray();
         if (array == null) {
-            throw new DecodingException("Expected a json array, but was given: " + value);
+        	JSONObject object = value.isObject();
+        	if(object == null){
+        		throw new DecodingException("Expected a json array, but was given: " + value);
+        	}
+        	array = new JSONArray();
+        	array.set(0, object);
         }
         return array;
     }

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -422,13 +422,15 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
     static JSONArray asArray(JSONValue value) {
         JSONArray array = value.isArray();
         if (array == null) {
+        	//Jersey render arrays with one object as object and not as array.
         	JSONObject object = value.isObject();
         	if(object == null){
         		throw new DecodingException("Expected a json array, but was given: " + value);
         	}
+        	//Found a object and return it as array.
         	array = new JSONArray();
         	array.set(0, object);
-        }
+        }        
         return array;
     }
 

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/Defaults.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/Defaults.java
@@ -41,6 +41,7 @@ public class Defaults {
     private static boolean dateFormatHasTimeZone = true;
     private static TimeZone timeZone = null;
     private static boolean ignoreJsonNulls = false;
+    private static boolean addXHttpMethodOverrideHeader = true;
     // patch TNY: timeout ms,
     // if >-1, used in Method class to set timeout
     private static int requestTimeout = -1;
@@ -203,4 +204,20 @@ public class Defaults {
     public static void setExceptionMapper(ExceptionMapper exceptionMapper) {
         Defaults.exceptionMapper = exceptionMapper;
     }
+
+    /**
+     * If true, the 'X-HTTP-Method-Override' header is set on each request.
+     * @return
+     */
+	public static boolean isAddXHttpMethodOverrideHeader() {
+		return addXHttpMethodOverrideHeader;
+	}
+
+	/**
+	 * If true, the 'X-HTTP-Method-Override' header is set on each request. Default is true.
+	 * @param addXHttpMethodOverrideHeader
+	 */
+	public static void setAddXHttpMethodOverrideHeader(boolean addXHttpMethodOverrideHeader) {
+		Defaults.addXHttpMethodOverrideHeader = addXHttpMethodOverrideHeader;
+	}
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
@@ -68,7 +68,9 @@ public class Method {
             //so if request does not have a body, Internet Explorer would send string "undefined" in the body of POST, PUT and DELETE requests,
             //which may cause the request to fall on server with "No operation matching request path"
             setRequestData(null);
-            setHeader("X-HTTP-Method-Override", method);
+            if(Defaults.isAddXHttpMethodOverrideHeader()){
+            	setHeader("X-HTTP-Method-Override", method);
+            }
         }
     }
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
@@ -58,6 +58,7 @@ import org.fusesource.restygwt.client.codec.EncoderDecoderTestGwt.WithEnum.Cycle
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.junit.client.GWTTestCase;
@@ -717,6 +718,40 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         		"{me<me@example.com>={me=[me<me@example.com>]}}",
                 roundtrip.toString());
     }
+    
+    /**
+     * Jersey encode arrays with one object as object and not as array.
+     */
+    @SuppressWarnings("unchecked")
+    public void testArrayAndCollectionWithOneElementAsObject() {
+
+        JSONValue json = JSONParser.parseStrict("{\"ages\":[1,2,3,4], " +
+        "\"emailArray\":{\"name\":\"me\", \"email\":\"me@example.com\"}, " +
+        "\"emailList\":{\"name\":\"me\", \"email\":\"me@example.com\"}, " +
+        "\"emailSet\":{\"name\":\"me\", \"email\":\"me@example.com\"}, " +
+		"\"emailListArray\":[[{\"name\":\"me\", \"email\":\"me@example.com\"}]], " +
+        "\"emailSetArray\":[[{\"name\":\"me\", \"email\":\"me@example.com\"}]], " +
+		"\"personalEmailList\":{\"me\":[{\"name\":\"me\", \"email\":\"me@example.com\"}]}, " +
+		"\"personalEmailSet\":{\"me\":[{\"name\":\"me\", \"email\":\"me@example.com\"}]}" +
+		", \"personalEmailListArray\":{\"me\":[[{\"name\":\"me\", \"email\":\"me@example.com\"}]]}" +
+		", \"personalEmailSetArray\":{\"me\":[[{\"name\":\"me\", \"email\":\"me@example.com\"}]]}" +
+        ", \"personalEmailSetList\":[{\"me\":[{\"name\":\"me\", \"email\":\"me@example.com\"}]}]" +
+        ", \"personalEmailListSet\":[{\"me\":[{\"name\":\"me\", \"email\":\"me@example.com\"}]}]" + 
+        ", \"personalEmailSetMap\":{\"{\\\"name\\\":\\\"me\\\", \\\"email\\\":\\\"me@example.com\\\"}\":" +
+        "{\"me\":[{\"name\":\"me\", \"email\":\"me@example.com\"}]}}" +
+		"}");
+        
+        AbstractJsonEncoderDecoder<WithArraysAndCollections> encoder = GWT.create(WithArraysAndCollectionsCodec.class);
+        
+        WithArraysAndCollections result = encoder.decode(json);
+        
+        assertEquals("[1, 2, 3, 4],[me<me@example.com>],[me<me@example.com>],{me=[me<me@example.com>]},null," +
+        		"[me<me@example.com>],{me=[me<me@example.com>]},[[me<me@example.com>]],[[me<me@example.com>]]," +
+        		"[me]=>[[me<me@example.com>]],[me]=>[[me<me@example.com>]],[{me=[me<me@example.com>]}],[{me=[me<me@example.com>]}]," +
+        		"{me<me@example.com>={me=[me<me@example.com>]}}",
+                result.toString());
+    }
+    
 
     static class CCC {
         


### PR DESCRIPTION
Jersy returns json arrays with only one element as object. I fixed this by trying to get the object and put it into an array.

Also I added an attribut to turn off the 'X-HTTP-Method-Override' header