### PR TITLE
Added support for OverlayCallback in DirectRestService

### DIFF
--- a/restygwt/src/it/restygwt-direct-example/pom.xml
+++ b/restygwt/src/it/restygwt-direct-example/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2009-2012 the original author or authors.
+    See the notice.md file distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.fusesource.restygwt</groupId>
+    <artifactId>restygwt-it-parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+  <artifactId>restygwt-direct-example</artifactId>
+  <version>@project.version@</version>
+  <packaging>war</packaging>
+
+  <name>RestyGWT Direct Example</name>
+
+  <description>
+    RestyGWT Examples
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+      <version>1.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/UI.gwt.xml
+++ b/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/UI.gwt.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2009-2012 the original author or authors.
+    See the notice.md file distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<module rename-to='ui'>
+
+  
+  <inherits name='com.google.gwt.user.User' />
+  <inherits name="org.fusesource.restygwt.RestyGWT" />
+
+  <servlet path='/pizza-service' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
+  <servlet path='/jsonp-service' class='org.fusesource.restygwt.examples.server.JsonpServlet'/>
+  <servlet path='/test/method' class='org.fusesource.restygwt.examples.server.TestServlet'/>
+  <servlet path='/test/fail' class='org.fusesource.restygwt.examples.server.TestServlet'/>
+  <servlet path='/test/JSONBinding/getListOfStrings' class='org.fusesource.restygwt.examples.server.TestServlet'/>
+  <servlet path='/test/JSONBinding/getStringMapResponse' class='org.fusesource.restygwt.examples.server.TestServlet'/>
+
+  <entry-point class='org.fusesource.restygwt.examples.client.UI'/>
+  <stylesheet src='ui.css' />
+
+</module>

--- a/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/Greeting.java
+++ b/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/Greeting.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.examples.client;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * Greeting Overlay type.
+ * @author iteratee@google.com (Kyle Butt)
+ */
+public class Greeting extends JavaScriptObject {
+
+  protected Greeting() { }
+
+  public final native String getGreeting() /*-{
+    return this.greeting;
+  }-*/;
+
+  public final native void setGreeting(String greeting) /*-{
+    this.greeting = greeting;
+  }-*/;
+}

--- a/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/GreetingService.java
+++ b/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/GreetingService.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.examples.client;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.fusesource.restygwt.client.DirectRestService;
+import org.fusesource.restygwt.client.OverlayCallback;
+import org.fusesource.restygwt.client.RestService;
+
+/**
+ * Simple service to demo the use of overlay objects.
+ * @author iteratee@google.com (Kyle Butt)
+ */
+@Path("/greeting-service")
+public interface GreetingService extends DirectRestService {
+
+    @GET Greeting getGreeting();
+
+    @POST Greeting getCustomGreeting(NameObject nameArg);
+}

--- a/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/NameObject.java
+++ b/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/NameObject.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.examples.client;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * Name Object Overlay Type.
+ * @author iteratee@google.com (Kyle Butt)
+ */
+public class NameObject extends JavaScriptObject {
+
+  protected NameObject() { }
+
+  public final native String getName() /*-{
+    return this.name;
+  }-*/;
+
+  public final native void setName(String name) /*-{
+    this.name = name;
+  }-*/;
+}

--- a/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/UI.java
+++ b/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/client/UI.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.examples.client;
+
+import org.fusesource.restygwt.client.JsonCallback;
+import org.fusesource.restygwt.client.Method;
+import org.fusesource.restygwt.client.OverlayCallback;
+import org.fusesource.restygwt.client.REST;
+import org.fusesource.restygwt.client.Resource;
+import org.fusesource.restygwt.client.RestServiceProxy;
+
+import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONValue;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.TextBox;
+
+/**
+ * Entry point classes define <code>onModuleLoad()</code>.
+ *
+ * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
+ */
+public class UI implements EntryPoint {
+
+    /**
+     * This is the entry point method.
+     */
+    public void onModuleLoad() {
+        Button button = new Button("Get Greeting");
+        button.addClickHandler(new ClickHandler() {
+            public void onClick(ClickEvent event) {
+                getGreeting();
+            }
+        });
+        RootPanel.get().add(button);
+        RootPanel.get().add(new Label("Name:"));
+        final TextBox nameInput = new TextBox();
+        RootPanel.get().add(nameInput);
+        Button customButton = new Button("Get Custom Greeting");
+        customButton.addClickHandler(new ClickHandler() {
+            public void onClick(ClickEvent event) {
+                getCustomGreeting(nameInput.getValue());
+            }
+        });
+        RootPanel.get().add(customButton);
+    }
+
+    private void getGreeting() {
+        GreetingService service = GWT.create(GreetingService.class);
+        Resource resource = new Resource(GWT.getModuleBaseURL() + "greeting-service");
+        ((RestServiceProxy) service).setResource(resource);
+
+        REST.withCallback(new OverlayCallback<Greeting>() {
+            public void onSuccess(Method method, Greeting greeting) {
+                RootPanel.get().add(new Label("server said: " + greeting.getGreeting()));
+            }
+
+            public void onFailure(Method method, Throwable exception) {
+                Window.alert("Error: " + exception);
+            }
+        }).call(service).getGreeting();
+    }
+
+    private void getCustomGreeting(String name) {
+        GreetingService service = GWT.create(GreetingService.class);
+        Resource resource = new Resource(GWT.getModuleBaseURL() + "greeting-service");
+        ((RestServiceProxy) service).setResource(resource);
+        NameObject arg = (NameObject) JavaScriptObject.createObject();
+        arg.setName(name);
+
+        REST.withCallback(new OverlayCallback<Greeting>() {
+            public void onSuccess(Method method, Greeting greeting) {
+                RootPanel.get().add(new Label("server said: " + greeting.getGreeting()));
+            }
+
+            public void onFailure(Method method, Throwable exception) {
+                Window.alert("Error: " + exception);
+            }
+        }).call(service).getCustomGreeting(arg);
+    }
+}

--- a/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/server/GreetingServlet.java
+++ b/restygwt/src/it/restygwt-direct-example/src/main/java/org/fusesource/restygwt/examples/server/GreetingServlet.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.examples.server;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.fusesource.restygwt.client.Resource;
+
+/**
+ * A simple server that serves JSON Data without constructing a Java Object.
+ *
+ * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
+ */
+public class GreetingServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -5364009274470240594L;
+    private static final String helloWorldJson = "{\"greeting\":\"Hello World\"}";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        System.out.println("Sending Hello World");
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode helloJsonNode = mapper.readTree(helloWorldJson);
+            mapper.writeValue(resp.getOutputStream(), helloJsonNode);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        } finally {
+            System.out.flush();
+            System.err.flush();
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        System.out.println("Creating custom greeting.");
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectNode nameObject = mapper.readValue(req.getInputStream(), ObjectNode.class);
+            String name = nameObject.get("name").asText();
+
+            String greeting = "Hello " + name;
+            ObjectNode resultObject = new ObjectNode(JsonNodeFactory.instance);
+            resultObject.put("greeting", greeting);
+            mapper.writeValue(resp.getOutputStream(), resultObject);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        } finally {
+            System.out.flush();
+            System.err.flush();
+        }
+    }
+}

--- a/restygwt/src/it/restygwt-direct-example/war/WEB-INF/web.xml
+++ b/restygwt/src/it/restygwt-direct-example/war/WEB-INF/web.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2009-2012 the original author or authors.
+    See the notice.md file distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<!DOCTYPE web-app
+    PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+    "http://java.sun.com/dtd/web-app_2_3.dtd">
+
+<web-app>
+  <servlet>
+    <servlet-name>greeting-service</servlet-name>
+    <servlet-class>org.fusesource.restygwt.examples.server.GreetingServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>greeting-service</servlet-name>
+    <url-pattern>/ui/greeting-service</url-pattern>
+  </servlet-mapping>
+
+  <welcome-file-list>
+    <welcome-file>ui/ui.html</welcome-file>
+  </welcome-file-list>
+</web-app>

--- a/restygwt/src/it/restygwt-direct-example/war/ui/ui.css
+++ b/restygwt/src/it/restygwt-direct-example/war/ui/ui.css
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Add css rules here for your application. */

--- a/restygwt/src/it/restygwt-direct-example/war/ui/ui.html
+++ b/restygwt/src/it/restygwt-direct-example/war/ui/ui.html
@@ -1,0 +1,64 @@
+<!--
+
+    Copyright (C) 2009-2012 the original author or authors.
+    See the notice.md file distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!--
+  Copyright 2009 Hiram Chirino
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+     http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <!--                                           -->
+    <!-- Any title is fine                         -->
+    <!--                                           -->
+    <title>Application</title>
+    
+    <!--                                           -->
+    <!-- This script loads your compiled module.   -->
+    <!-- If you add any GWT meta tags, they must   -->
+    <!-- be added before this line.                -->
+    <!--                                           -->
+    <script type="text/javascript" language="javascript" src="ui.nocache.js"></script>
+  </head>
+
+  <!--                                           -->
+  <!-- The body can have arbitrary html, or      -->
+  <!-- you can leave the body empty if you want  -->
+  <!-- to create a completely dynamic UI.        -->
+  <!--                                           -->
+  <body>
+
+    <!-- OPTIONAL: include this if you want history support -->
+    <iframe src="javascript:''" id="__gwt_historyFrame" tabIndex='-1' style="position:absolute;width:0;height:0;border:0"></iframe>
+  
+  </body>
+</html>

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestBaseSourceCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestBaseSourceCreator.java
@@ -17,19 +17,25 @@
  */
 package org.fusesource.restygwt.rebind;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
-import com.google.gwt.core.ext.typeinfo.JClassType;
-import com.google.gwt.core.ext.typeinfo.JGenericType;
-import com.google.gwt.core.ext.typeinfo.JTypeParameter;
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.core.ext.typeinfo.*;
 import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
 
 /**
  * @author <a href="mailto:bogdan.mustiata@gmail.com">Bogdan Mustiata</a>
  */
 public abstract class DirectRestBaseSourceCreator extends BaseSourceCreator {
+    private JClassType OVERLAY_VALUE_TYPE;
+
     public DirectRestBaseSourceCreator(TreeLogger logger, GeneratorContext context, JClassType source, String suffix) {
         super(logger, context, source, suffix);
+    }
+
+    @Override protected void generate() throws UnableToCompleteException {
+        this.OVERLAY_VALUE_TYPE = find(JavaScriptObject.class, getLogger(), context);
     }
 
     protected ClassSourceFileComposerFactory createClassSourceComposerFactory(JavaSourceCategory createWhat,
@@ -84,4 +90,8 @@ public abstract class DirectRestBaseSourceCreator extends BaseSourceCreator {
         return parameters;
     }
 
+    protected boolean isOverlayMethod(JMethod method) {
+        final JClassType aClass = method.getReturnType().isClass();
+        return aClass != null && OVERLAY_VALUE_TYPE.isAssignableFrom(aClass);
+    }
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
@@ -1,5 +1,6 @@
 package org.fusesource.restygwt.rebind;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
@@ -38,6 +39,8 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
 
     @Override
     protected void generate() throws UnableToCompleteException {
+        super.generate();
+
         createRestyServiceField();
         createDelegateRestServiceProxyMethods();
         createCallbackSupportMethodsAndField();
@@ -112,8 +115,12 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
                     .append(parameter.getName());
         }
 
-        stringBuilder.append(comma.next())
-                .append("this.callback");
+        stringBuilder.append(comma.next());
+        if (isOverlayMethod(method)) {
+            stringBuilder.append("(org.fusesource.restygwt.client.OverlayCallback) this.callback");
+        } else {
+            stringBuilder.append("this.callback");
+        }
 
         stringBuilder.append(");");
 

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
@@ -56,6 +56,8 @@ public class DirectRestServiceInterfaceClassCreator extends DirectRestBaseSource
 
     @Override
     protected void generate() throws UnableToCompleteException {
+        super.generate();
+
         for (JMethod method : source.getInheritableMethods()) {
             p(getAnnotationsAsString(method.getAnnotations()));
             p("void " + method.getName() + "(" + getMethodParameters(method) + getMethodCallback(method) + ");");
@@ -81,7 +83,12 @@ public class DirectRestServiceInterfaceClassCreator extends DirectRestBaseSource
         if (isVoidMethod(method)) {
             return "org.fusesource.restygwt.client.MethodCallback<java.lang.Void> callback";
         }
-        return "org.fusesource.restygwt.client.MethodCallback<" + method.getReturnType().getParameterizedQualifiedSourceName() + "> callback";
+        final String returnType = method.getReturnType().getParameterizedQualifiedSourceName();
+        if (isOverlayMethod(method)) {
+            return "org.fusesource.restygwt.client.OverlayCallback<" + returnType + "> callback";
+        } else {
+            return "org.fusesource.restygwt.client.MethodCallback<" + returnType + "> callback";
+        }
     }
 
     private String getAnnotationsAsString(Annotation[] annotations) {


### PR DESCRIPTION
Actual change https://github.com/resty-gwt/resty-gwt/commit/0fc2aba8fe6b078a745c27dcc941b2bf8e01bac0. Second commit is just a copy of restygwt-overlay-example modifying the service to use DirectRestService instead of RestService. So now there are an example of direct service usage in IT.