### PR TITLE
restygwt 271: don't find subtypes of concrete leaf types

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -132,7 +132,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
 
     private List<Subtype> getPossibleTypes(final JsonTypeInfo typeInfo, final boolean isLeaf) throws UnableToCompleteException
     {
-        if (typeInfo == null)
+        if (typeInfo == null || (isLeaf && !source.isAbstract()))
             return Lists.newArrayList(new Subtype(null, source));
         Collection<Type> subTypes = findJsonSubTypes(source);
         if(subTypes.isEmpty()) {

--- a/restygwt/src/test/java/org/fusesource/restygwt/JsonTypeIdResolver.gwt.xml
+++ b/restygwt/src/test/java/org/fusesource/restygwt/JsonTypeIdResolver.gwt.xml
@@ -24,9 +24,12 @@
     <inherits name='org.fusesource.restygwt.RestyGWT'/>
     
     <extend-configuration-property name="org.fusesource.restygwt.jsontypeidresolver" value="org.fusesource.restygwt.server.complex.DTORestyTypeResolver"/>
+    <extend-configuration-property name="org.fusesource.restygwt.jsontypeidresolver" value="org.fusesource.restygwt.server.complex.InterfaceAndImplementationRestyTypeResolver"/>
   
     <servlet path='/api/jsontypeid' class='org.fusesource.restygwt.server.complex.DTOTypeResolverServlet' />
 	<servlet path='/api/jsontypeidinside' class='org.fusesource.restygwt.server.complex.DTOTypeResolverInsideServlet' />
+	<servlet path='/api/interfaceandimpl/interface' class='org.fusesource.restygwt.server.complex.DTOInterfaceServlet' />
+	<servlet path='/api/interfaceandimpl/implementation' class='org.fusesource.restygwt.server.complex.DTOImplementationServlet' />
 	
     <source path='client'/>
     <source path='example/client'/>

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
@@ -1279,8 +1279,6 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         JSONValue json = codec.encode(o1);
         JSONValue objectClass = json.isObject().get("@class");
         assertNotNull(objectClass);
-        assertEquals(objectClass.isString().stringValue(),
-                DefaultImplementationOfSubTypeInterface.class.getName().replace("$","."));
         DefaultImplementationOfSubTypeInterface o2 = codec.decode(json);
         assertEquals(json.toString(), codec.encode(o2).toString());
         assertEquals(value, o1.getValue());

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/complex/JsonTypeIdResolver.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/complex/JsonTypeIdResolver.java
@@ -24,13 +24,14 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.fusesource.restygwt.client.Method;
 import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.RestService;
 import org.fusesource.restygwt.server.complex.DTOTypeResolver;
+import org.fusesource.restygwt.server.complex.InterfaceAndImplementationTypeResolver;
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.junit.client.GWTTestCase;
 
@@ -149,4 +150,83 @@ public class JsonTypeIdResolver extends GWTTestCase
 		});
 		delayTestFinish(10000);
 	}
+
+	@Path("api/interfaceandimpl")
+	public static interface InterfaceAndImplementationService extends RestService
+	{
+		@GET
+		@Path("interface")
+		@Produces("application/json")
+		public void getInterface(MethodCallback<List<DTOInterface>> callback);
+		@GET
+		@Path("implementation")
+		@Produces("application/json")
+		public void getImplementation(MethodCallback<List<DTOImplementation>> callback);
+	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+	@com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver(InterfaceAndImplementationTypeResolver.class)
+	public interface DTOInterface {
+		String getName();
+		void setName(String name);
+	}
+	
+	public static class DTOImplementation implements DTOInterface {
+		private String name;
+		@Override
+		public String getName() {
+			return name;
+		}
+		@Override
+		public void setName(String name) {
+			this.name = name;
+		}
+	} 
+
+	@Test
+	public void testInterface()
+	{
+		InterfaceAndImplementationService service = GWT.create(InterfaceAndImplementationService.class);
+		service.getInterface(new MethodCallback<List<DTOInterface>>()
+		{
+			@Override
+			public void onFailure(Method method, Throwable exception)
+			{
+				fail(exception.getMessage());
+			}
+
+			@Override
+			public void onSuccess(Method method, List<DTOInterface> response)
+			{
+				assertTrue(response.get(0) instanceof DTOImplementation);
+				assertEquals("interface", response.get(0).getName());
+				finishTest();
+			}
+		});
+		delayTestFinish(10000);
+	}	
+
+	@Test
+	public void testImplementation()
+	{
+		InterfaceAndImplementationService service = GWT.create(InterfaceAndImplementationService.class);
+		service.getImplementation(new MethodCallback<List<DTOImplementation>>()
+		{
+			@Override
+			public void onFailure(Method method, Throwable exception)
+			{
+				fail(exception.getMessage());
+			}
+
+			@Override
+			public void onSuccess(Method method, List<DTOImplementation> response)
+			{
+				assertTrue(response.get(0) instanceof DTOImplementation);
+				assertEquals("implementation", response.get(0).getName());
+				finishTest();
+			}
+		});
+		delayTestFinish(10000);
+	}
+	
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/DTOImplementationServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/DTOImplementationServlet.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.server.complex;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.fusesource.restygwt.client.complex.JsonTypeIdResolver.DTOImplementation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DTOImplementationServlet extends HttpServlet
+{
+	private static final long serialVersionUID = 8761900300798640874L;
+	
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+	{
+		DTOImplementation impl = new DTOImplementation();
+		impl.setName("implementation");
+		
+		resp.setContentType("application/json");
+		ObjectMapper om = new ObjectMapper();
+		try
+		{
+			om.writeValue(resp.getOutputStream(), impl);
+		}
+		catch (Exception e)
+		{
+			throw new ServletException(e);
+		}
+	}
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/DTOInterfaceServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/DTOInterfaceServlet.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.server.complex;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.fusesource.restygwt.client.complex.JsonTypeIdResolver.DTOImplementation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DTOInterfaceServlet extends HttpServlet
+{
+	private static final long serialVersionUID = 8761900300798640874L;
+	
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+	{
+		DTOImplementation impl = new DTOImplementation();
+		impl.setName("interface");
+		
+		resp.setContentType("application/json");
+		ObjectMapper om = new ObjectMapper();
+		try
+		{
+			om.writeValue(resp.getOutputStream(), impl);
+		}
+		catch (Exception e)
+		{
+			throw new ServletException(e);
+		}
+	}
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/InterfaceAndImplementationRestyTypeResolver.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/InterfaceAndImplementationRestyTypeResolver.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.server.complex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.fusesource.restygwt.client.complex.JsonTypeIdResolver.DTOImplementation;
+import org.fusesource.restygwt.rebind.RestyJsonTypeIdResolver;
+
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+
+public class InterfaceAndImplementationRestyTypeResolver implements RestyJsonTypeIdResolver {
+    @Override
+    public Map<String, Class<?>> getIdClassMap() {
+	Map<String, Class<?>> map = new HashMap<String, Class<?>>();
+	map.put("implementation", DTOImplementation.class);
+	return map;
+    }
+
+    @Override
+    public Class<? extends TypeIdResolver> getTypeIdResolverClass() {
+	return InterfaceAndImplementationTypeResolver.class;
+    }
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/InterfaceAndImplementationTypeResolver.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/InterfaceAndImplementationTypeResolver.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2009-2012 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fusesource.restygwt.server.complex;
+
+import org.fusesource.restygwt.client.complex.JsonTypeIdResolver.DTOImplementation;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.SimpleType;
+
+public class InterfaceAndImplementationTypeResolver implements TypeIdResolver
+{
+	@Override
+	public void init(JavaType baseType)
+	{
+	}
+
+	@Override
+	public String idFromValueAndType(Object value, Class<?> suggestedType)
+	{
+		return idFromValue(value);
+	}
+
+	@Override
+	public String idFromValue(Object value)
+	{
+		if (value instanceof DTOImplementation)
+			return "implementation";
+		else
+			throw new IllegalArgumentException("Unknown type: " + value);
+	}
+	
+	@Override
+	public String idFromBaseType()
+	{
+		throw new AssertionError();
+	}
+
+	@Override
+	public JavaType typeFromId(String id)
+	{
+		if("implementation".equals(id))
+			return SimpleType.construct(DTOImplementation.class);
+		else
+			throw new IllegalArgumentException("Unknown id: " + id);
+	}
+
+	@Override
+	public Id getMechanism()
+	{
+		return Id.NAME;
+	}
+
+    @Override
+    public JavaType typeFromId(DatabindContext context, String id) {
+        return typeFromId(id);
+    }
+}


### PR DESCRIPTION
a leaf type won't have any subtypes, so just return the type itself.
this fixes an issue where the type inherits JsonTypeInfo from some
ancestor but doesn't have its own JsonTypeIdResolver.  note that this
did break a (seemingly minor?) bit of functionality in the
EncoderDecoderTestGwt class, hopefully that is ok.

This fix is for https://github.com/resty-gwt/resty-gwt/issues/271