### PR TITLE
Fix #273 - Use naming convention for getters/setters

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/RestyGWT.gwt.xml
+++ b/restygwt/src/main/java/org/fusesource/restygwt/RestyGWT.gwt.xml
@@ -54,11 +54,23 @@
     Declare a property to determine whether autodetection of text/* with @Consumes and @Produces annotations should be used.
   -->
   <define-property name="restygwt.autodetect.plainText" values="true,false" />
-  
+
+  <!--
+    Declare a property to determine whether the detection for Accessor and Mutator should follow the naming convention from JavaBeans API specification.
+  -->
+  <define-property name="restygwt.conventions.useJavaBeansSpecNaming" values="true,false" />
+
+
   <!--
     Default no autodetection for text/*, for backward compatibility.
   -->
   <set-property name="restygwt.autodetect.plainText" value="false" />
+
+  <!--
+    Use JavaBeans naming convention by default.
+  -->
+  <set-property name="restygwt.conventions.useJavaBeansSpecNaming" value="true" />
+
 
   <source path="client"/>
   <source path="example/client"/>

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
@@ -21,7 +21,10 @@ package org.fusesource.restygwt.rebind;
 import java.io.PrintWriter;
 import java.util.HashSet;
 
+import com.google.gwt.core.ext.BadPropertyValueException;
 import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.PropertyOracle;
+import com.google.gwt.core.ext.SelectionProperty;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
@@ -216,6 +219,20 @@ public abstract class BaseSourceCreator extends AbstractSourceCreator {
         generate();
         sourceWriter.commit(getLogger());
         return name;
+    }
+
+    /**
+     * Returns the boolean value of the property or the default value.
+     */
+    protected static boolean getBooleanProperty(TreeLogger logger, PropertyOracle propertyOracle, String propertyName, boolean defaultValue) {
+        try {
+            SelectionProperty prop = propertyOracle.getSelectionProperty(logger, propertyName);
+            String propVal = prop.getCurrentValue();
+            return Boolean.parseBoolean(propVal);
+        } catch (BadPropertyValueException e) {
+            // return the default value
+        }
+        return defaultValue;
     }
 
     abstract protected ClassSourceFileComposerFactory createComposerFactory() throws UnableToCompleteException;

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -750,6 +750,19 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
     return null;
     }
 
+    /**
+     * Get the middle part of the method name in compliance with the naming convention in the JavaBeans API specification.
+     * 
+     * @param fieldName
+     * @return
+     */
+    static String getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(String fieldName) {
+        if (fieldName.length() > 1 && Character.isUpperCase(fieldName.charAt(1))) {
+            return fieldName;
+        }
+        return fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+    }
+
     private String upperCaseFirstChar(String in) {
 	if (in.length() == 1) {
 	    return in.toUpperCase();

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -94,7 +94,8 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
     public JsonEncoderDecoderClassCreator(TreeLogger logger, GeneratorContext context, JClassType source) {
         super(logger, context, source, JSON_ENCODER_SUFFIX);
 
-        javaBeansNamingConventionEnabled = false;
+        // true, if the naming convention from JavaBeans API specification should be used
+        javaBeansNamingConventionEnabled = getBooleanProperty(getLogger(), context.getPropertyOracle(), USE_JAVA_BEANS_SPEC_NAMING_CONVENTION_CONFIGURATION_PROPERTY_NAME, true);
     }
 
     @Override

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -72,10 +72,7 @@ import com.google.gwt.core.client.JsArrayBoolean;
 import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.core.client.JsArrayNumber;
 import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.core.ext.BadPropertyValueException;
 import com.google.gwt.core.ext.GeneratorContext;
-import com.google.gwt.core.ext.PropertyOracle;
-import com.google.gwt.core.ext.SelectionProperty;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.HasAnnotations;
@@ -215,7 +212,8 @@ public class RestServiceClassCreator extends BaseSourceCreator {
             throw new UnableToCompleteException();
         }
 
-        autodetectTypeForStrings = shouldAutodetectPlainTextForStrings(getLogger(), context.getPropertyOracle());
+        // true, if plain text autodetection for strings should be used
+        autodetectTypeForStrings = getBooleanProperty(getLogger(), context.getPropertyOracle(), PLAIN_TEXT_AUTODETECTION_CONFIGURATION_PROPERTY_NAME, false);
 
         locator = new JsonEncoderDecoderInstanceLocator(context, getLogger());
 
@@ -303,20 +301,6 @@ public class RestServiceClassCreator extends BaseSourceCreator {
         	else
                 writeMethodImpl(method, options);
         }
-    }
-
-    /**
-     * Returns {@code true} if plain text autodetection for strings should be used.
-     */
-    static boolean shouldAutodetectPlainTextForStrings(TreeLogger logger, PropertyOracle propertyOracle) {
-        try {
-            SelectionProperty prop = propertyOracle.getSelectionProperty(logger, PLAIN_TEXT_AUTODETECTION_CONFIGURATION_PROPERTY_NAME);
-            String propVal = prop.getCurrentValue();
-            return Boolean.parseBoolean(propVal);
-        } catch (BadPropertyValueException e) {
-            // use default "false"
-        }
-        return false;
     }
 
     private static String getPathFromSource(HasAnnotations annotatedType) {

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
@@ -1343,4 +1343,39 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         assertEquals("{\"@class\":\"org.fusesource.restygwt.client.codec.EncoderDecoderTestGwt.SubForJsonProperty\", \"otherField\":\"other-field-value\", \"myField\":\"my-field-value\"}", json.toString());
     }
 
+    public class BeanNamingConvention {
+        private Integer xValue;
+        private Integer myValue;
+
+        public Integer getxValue() {
+            return xValue;
+        }
+
+        public void setxValue(Integer xValue) {
+            this.xValue = xValue;
+        }
+
+        public Integer getMyValue() {
+            return myValue;
+        }
+
+        public void setMyValue(Integer myValue) {
+            this.myValue = myValue;
+        }
+    }
+
+    static interface BeanNamingConventionCodec extends JsonEncoderDecoder<BeanNamingConvention> {
+    }
+
+    public void testBeanNamingConvention() {
+        BeanNamingConventionCodec codec = GWT.create(BeanNamingConventionCodec.class);
+
+        BeanNamingConvention bean = new BeanNamingConvention();
+        bean.setxValue(1);
+        bean.setMyValue(3);
+        JSONValue json = codec.encode(bean);
+
+        assertEquals("{\"xValue\":1, \"myValue\":3}", json.toString());
+    }
+
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreatorTestCase.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreatorTestCase.java
@@ -1,5 +1,6 @@
 package org.fusesource.restygwt.rebind;
 
+import java.beans.Introspector;
 import java.util.Collection;
 import java.util.List;
 
@@ -18,6 +19,8 @@ import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
+
+import static org.fusesource.restygwt.rebind.JsonEncoderDecoderClassCreator.getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance;
 
 @RunWith(JUnit4.class)
 public class JsonEncoderDecoderClassCreatorTestCase extends TestCase
@@ -89,4 +92,32 @@ public class JsonEncoderDecoderClassCreatorTestCase extends TestCase
         assertEquals(v.hasEnteredGetPossibleTypesForClass, classMethodVisited);
         assertEquals(v.hasEnteredGetPossibleTypesForOther, otherMethodVisited);
     }
+
+    @Test
+    public void testNamingConventions() {
+        String name = "a";
+        assertEquals("A", getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name));
+        assertEquals(name, Introspector.decapitalize(getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name)));
+
+        name = "foo";
+        assertEquals("Foo", getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name));
+        assertEquals(name, Introspector.decapitalize(getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name)));
+
+        name = "URL";
+        assertEquals("URL", getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name));
+        assertEquals(name, Introspector.decapitalize(getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name)));
+
+        name = "xValue";
+        assertEquals("xValue", getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name));
+        assertEquals(name, Introspector.decapitalize(getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name)));
+
+        name = "myValue";
+        assertEquals("MyValue", getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name));
+        assertEquals(name, Introspector.decapitalize(getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name)));
+
+        name = "MYTestValue";
+        assertEquals("MYTestValue", getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name));
+        assertEquals(name, Introspector.decapitalize(getMiddleNameForPrefixingAsAccessorMutatorJavaBeansSpecCompliance(name)));
+    }
+
 }


### PR DESCRIPTION
Fix for #273

I have decided to enabled the use of JavaBeans naming convention by default because I think it's a rare case. However to preserve backwards compatibility a new property was added to enable the old behavior.

Thanks to @natros for the useful bug report and providing the information.

closes #273 
