### PR TITLE
Search type hierarchy for a JsonTypeIdResolver

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -132,7 +132,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
 
     private List<Subtype> getPossibleTypes(final JsonTypeInfo typeInfo, final boolean isLeaf) throws UnableToCompleteException
     {
-        if (typeInfo == null || (isLeaf && !source.isAbstract()))
+        if (typeInfo == null)
             return Lists.newArrayList(new Subtype(null, source));
         Collection<Type> subTypes = findJsonSubTypes(source);
         if(subTypes.isEmpty()) {

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
@@ -82,7 +82,7 @@ public class PossibleTypesVisitor extends JsonTypeInfoIdVisitor<List<Subtype>, U
     {
         final List<Subtype> possibleTypes = Lists.newArrayList();
 
-        final JsonTypeIdResolver typeResolver = getAnnotation(classType, JsonTypeIdResolver.class);
+        final JsonTypeIdResolver typeResolver = getClassAnnotation(classType, JsonTypeIdResolver.class);
         if (typeResolver != null) {
             Class<? extends TypeIdResolver> resolverClass = typeResolver.value();
             RestyJsonTypeIdResolver restyResolver;

--- a/restygwt/src/test/java/org/fusesource/restygwt/ParameterizedTypeServiceInterface.gwt.xml
+++ b/restygwt/src/test/java/org/fusesource/restygwt/ParameterizedTypeServiceInterface.gwt.xml
@@ -25,6 +25,10 @@
     
     <servlet path='/api/ptype/int' class='org.fusesource.restygwt.server.complex.ParameterizedTypeServlet$IntServlet' />
     <servlet path='/api/ptype/thing' class='org.fusesource.restygwt.server.complex.ParameterizedTypeServlet$ThingServlet' />
+    <servlet path='/api/concrete/echo' class='org.fusesource.restygwt.server.complex.ParameterizedTypeServlet$EchoNameServlet' />
+    
+    <extend-configuration-property name='org.fusesource.restygwt.jsontypeidresolver'
+    	value='org.fusesource.restygwt.server.complex.InterfaceAndImplementationRestyTypeResolver' />
 
     <source path='client'/>
     <source path='example/client'/>

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/ParameterizedTypeServiceInterfaces.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/ParameterizedTypeServiceInterfaces.java
@@ -19,12 +19,15 @@
 package org.fusesource.restygwt.client.basic;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 import org.fusesource.restygwt.client.Method;
 import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.RestService;
+import org.fusesource.restygwt.client.complex.JsonTypeIdResolver.DTOImplementation;
+import org.fusesource.restygwt.client.complex.JsonTypeIdResolver.DTOInterface;
 import org.junit.Test;
 
 import com.google.gwt.core.client.GWT;
@@ -70,6 +73,15 @@ public class ParameterizedTypeServiceInterfaces extends GWTTestCase
 		@Path("int")
 		public A<Integer> getIntInterface();
 	}
+	
+	public static interface GenericService<T extends DTOInterface> extends RestService {
+		@POST
+		@Path("echo")
+		void echoName(T dto, MethodCallback<String> callback);
+	}
+	
+	@Path("/api/concrete")
+	public static interface ConcreteService extends GenericService<DTOImplementation> { }
 
 	@Test
 	public void testSimpleType()
@@ -160,4 +172,29 @@ public class ParameterizedTypeServiceInterfaces extends GWTTestCase
 		});
 		delayTestFinish(10000);
 	}
+	
+	@Test
+	public void testGenericService()
+	{
+		final DTOImplementation dto = new DTOImplementation();
+		dto.setName("impl name");
+		ConcreteService service = GWT.create(ConcreteService.class);
+		service.echoName(dto, new MethodCallback<String>()
+		{
+			@Override
+			public void onFailure(Method method, Throwable exception)
+			{
+				fail(exception.getMessage());
+			}
+
+			@Override
+			public void onSuccess(Method method, String response)
+			{
+				assertEquals(dto.getName(), response);;
+				finishTest();
+			}
+		});
+		delayTestFinish(10000);
+	}
+	
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/PolymorphicEncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/PolymorphicEncoderDecoderTestGwt.java
@@ -100,6 +100,8 @@ public class PolymorphicEncoderDecoderTestGwt extends GWTTestCase {
         JSONValue json = codec.encode(o1);
         JSONValue objectClass = json.isObject().get("@class");
         assertNotNull(objectClass);
+        assertEquals(DefaultImplementationOfSubTypeInterface.class.getName().replace("$","."),
+        		objectClass.isString().stringValue());
         DefaultImplementationOfSubTypeInterface o2 = codec.decode(json);
         assertEquals(json.toString(), codec.encode(o2).toString());
         assertEquals(value, o1.getValue());

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/ParameterizedTypeServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/ParameterizedTypeServlet.java
@@ -18,21 +18,30 @@
 
 package org.fusesource.restygwt.server.complex;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.fusesource.restygwt.client.basic.ParameterizedTypeServiceInterfaces;
 import org.fusesource.restygwt.client.basic.ParameterizedTypeServiceInterfaces.Thing;
+import org.fusesource.restygwt.client.complex.JsonTypeIdResolver.DTOInterface;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 
 @SuppressWarnings("serial")
 public class ParameterizedTypeServlet
 {
-	public static abstract class JacksonServlet extends HttpServlet
+	/**
+	 * Ignores input and outputs a value.
+	 */
+	public static abstract class JacksonOutputServlet extends HttpServlet
 	{
 		@Override
 		protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
@@ -45,7 +54,7 @@ public class ParameterizedTypeServlet
 		protected abstract Object getThing();
 	}
 	
-	public static class IntServlet extends JacksonServlet
+	public static class IntServlet extends JacksonOutputServlet
 	{
 		@Override
 		protected Integer getThing()
@@ -55,7 +64,7 @@ public class ParameterizedTypeServlet
 		
 	}
 	
-	public static class ThingServlet extends JacksonServlet
+	public static class ThingServlet extends JacksonOutputServlet
 	{
 		@Override
 		protected ParameterizedTypeServiceInterfaces.Thing getThing()
@@ -64,6 +73,20 @@ public class ParameterizedTypeServlet
 			thing.name = "Fred Flintstone";
 			thing.shoeSize = 12;
 			return thing;
+		}
+	}
+	
+	
+	public static class EchoNameServlet extends HttpServlet
+	{
+		@Override
+		protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+		{
+			ObjectMapper mapper = new ObjectMapper();
+			ObjectReader reader = mapper.reader(DTOInterface.class);
+			DTOInterface dto = reader.readValue(req.getInputStream());
+			resp.setContentType("application/json");
+			mapper.writeValue(resp.getOutputStream(), dto.getName());
 		}
 	}
 }


### PR DESCRIPTION
Search a class's super classes and implemented interfaces when looking
for a JsonTypeIdResolver, since it will most likely be declared
somewhere near the root of the hierarchy.  This is the proper fix for
the issue #271, and undoes the changes in PR #272.

This fixes issue #277.