### PR TITLE
Support primitive return types in DirectRestServices

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
@@ -6,6 +6,7 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
 import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.core.ext.typeinfo.JParameter;
+import com.google.gwt.core.ext.typeinfo.JPrimitiveType;
 import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
 import org.fusesource.restygwt.client.Dispatcher;
 import org.fusesource.restygwt.client.MethodCallback;
@@ -121,8 +122,14 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
     }
 
     private void generateReturnNull(JMethod method) {
-        // FIXME: check for primitives, void.
-        if (!isVoidMethod(method)) {
+    	if (isVoidMethod(method)) {
+    		// check void first since JPrimitiveType will consider void to be
+    		// a primitive
+    		return;
+    	} else if (method.getReturnType().isPrimitive() != null) {
+        	JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
+        	p("return " + primitiveType.getUninitializedFieldExpression() + ";");
+    	} else {
             p("return null;");
         }
     }
@@ -130,7 +137,7 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
     public static boolean isVoidMethod(JMethod method) {
         return VOID_QUALIFIED_NAME.equals(method.getReturnType().getQualifiedBinaryName());
     }
-
+    
     private void createCallbackField() {
         p("private " + MethodCallback.class.getCanonicalName() + " callback;");
     }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
@@ -123,8 +123,7 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
 
     private void generateReturnNull(JMethod method) {
     	if (isVoidMethod(method)) {
-    		// check void first since JPrimitiveType will consider void to be
-    		// a primitive
+    		// check void first since JPrimitiveType will consider void to be a primitive
     		return;
     	} else if (method.getReturnType().isPrimitive() != null) {
         	JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
@@ -134,7 +133,7 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
         }
     }
 
-    public static boolean isVoidMethod(JMethod method) {
+    private static boolean isVoidMethod(JMethod method) {
         return VOID_QUALIFIED_NAME.equals(method.getReturnType().getQualifiedBinaryName());
     }
     

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
@@ -122,10 +122,10 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
     }
 
     private void generateReturnNull(JMethod method) {
-    	if (isVoidMethod(method)) {
-    		// check void first since JPrimitiveType will consider void to be a primitive
-    		return;
-    	} else if (method.getReturnType().isPrimitive() != null) {
+        if (isVoidMethod(method)) {
+        	// check void first since JPrimitiveType will consider void to be a primitive
+        	return;
+        } else if (method.getReturnType().isPrimitive() != null) {
         	JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
         	p("return " + primitiveType.getUninitializedFieldExpression() + ";");
     	} else {
@@ -136,7 +136,7 @@ public class DirectRestServiceClassCreator extends DirectRestBaseSourceCreator {
     private static boolean isVoidMethod(JMethod method) {
         return VOID_QUALIFIED_NAME.equals(method.getReturnType().getQualifiedBinaryName());
     }
-    
+
     private void createCallbackField() {
         p("private " + MethodCallback.class.getCanonicalName() + " callback;");
     }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
@@ -23,6 +23,7 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
 import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.core.ext.typeinfo.JParameter;
+import com.google.gwt.core.ext.typeinfo.JPrimitiveType;
 import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
 import org.fusesource.restygwt.client.RestService;
 import org.fusesource.restygwt.rebind.util.AnnotationCopyUtil;
@@ -80,6 +81,9 @@ public class DirectRestServiceInterfaceClassCreator extends DirectRestBaseSource
     private String getMethodCallback(JMethod method) {
         if (isVoidMethod(method)) {
             return "org.fusesource.restygwt.client.MethodCallback<java.lang.Void> callback";
+        } else if (method.getReturnType().isPrimitive() != null) {
+        	JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
+        	return "org.fusesource.restygwt.client.MethodCallback<" + primitiveType.getQualifiedBoxedSourceName() + "> callback";
         }
         return "org.fusesource.restygwt.client.MethodCallback<" + method.getReturnType().getParameterizedQualifiedSourceName() + "> callback";
     }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
@@ -79,8 +79,8 @@ public class DirectRestServiceInterfaceClassCreator extends DirectRestBaseSource
 
     private String getMethodCallback(JMethod method) {
         if (method.getReturnType().isPrimitive() != null) {
-        	JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
-        	return "org.fusesource.restygwt.client.MethodCallback<" + primitiveType.getQualifiedBoxedSourceName() + "> callback";
+            JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
+            return "org.fusesource.restygwt.client.MethodCallback<" + primitiveType.getQualifiedBoxedSourceName() + "> callback";
         }
         return "org.fusesource.restygwt.client.MethodCallback<" + method.getReturnType().getParameterizedQualifiedSourceName() + "> callback";
     }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
@@ -17,6 +17,13 @@
  */
 package org.fusesource.restygwt.rebind;
 
+import java.lang.annotation.Annotation;
+
+import org.fusesource.restygwt.client.RestService;
+import org.fusesource.restygwt.rebind.util.AnnotationCopyUtil;
+import org.fusesource.restygwt.rebind.util.AnnotationUtils;
+import org.fusesource.restygwt.rebind.util.OnceFirstIterator;
+
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
@@ -25,14 +32,6 @@ import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.core.ext.typeinfo.JParameter;
 import com.google.gwt.core.ext.typeinfo.JPrimitiveType;
 import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
-import org.fusesource.restygwt.client.RestService;
-import org.fusesource.restygwt.rebind.util.AnnotationCopyUtil;
-import org.fusesource.restygwt.rebind.util.AnnotationUtils;
-import org.fusesource.restygwt.rebind.util.OnceFirstIterator;
-
-import java.lang.annotation.Annotation;
-
-import static org.fusesource.restygwt.rebind.DirectRestServiceClassCreator.isVoidMethod;
 
 /**
  * @author <a href="mailto:bogdan.mustiata@gmail.com">Bogdan Mustiata</a>
@@ -79,9 +78,7 @@ public class DirectRestServiceInterfaceClassCreator extends DirectRestBaseSource
     }
 
     private String getMethodCallback(JMethod method) {
-        if (isVoidMethod(method)) {
-            return "org.fusesource.restygwt.client.MethodCallback<java.lang.Void> callback";
-        } else if (method.getReturnType().isPrimitive() != null) {
+        if (method.getReturnType().isPrimitive() != null) {
         	JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
         	return "org.fusesource.restygwt.client.MethodCallback<" + primitiveType.getQualifiedBoxedSourceName() + "> callback";
         }

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
@@ -40,7 +40,7 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
         @GET @Path("/something")
         void getSomething();
     }
-
+    
     public void testCallingMethodsDirectlyShouldFail() {
         delayTestFinish(10000);
         DirectExampleService directExampleService = GWT.create(DirectExampleService.class);
@@ -97,6 +97,11 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
     public void testInnerInterface() {
         InnerDirectRestService innerDirectService = GWT.create(InnerDirectRestService.class);
         assertNotNull(innerDirectService);
+    }
+    
+    public void testPrimitiveDirectRestService() {
+    	PrimitiveDirectRestService primitiveDirectService = GWT.create(PrimitiveDirectRestService.class);
+        assertNotNull(primitiveDirectService);
     }
 
 }

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
@@ -40,7 +40,7 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
         @GET @Path("/something")
         void getSomething();
     }
-    
+
     public void testCallingMethodsDirectlyShouldFail() {
         delayTestFinish(10000);
         DirectExampleService directExampleService = GWT.create(DirectExampleService.class);
@@ -98,9 +98,9 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
         InnerDirectRestService innerDirectService = GWT.create(InnerDirectRestService.class);
         assertNotNull(innerDirectService);
     }
-    
+
     public void testPrimitiveDirectRestService() {
-    	PrimitiveDirectRestService primitiveDirectService = GWT.create(PrimitiveDirectRestService.class);
+        PrimitiveDirectRestService primitiveDirectService = GWT.create(PrimitiveDirectRestService.class);
         assertNotNull(primitiveDirectService);
     }
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PrimitiveDirectRestService.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PrimitiveDirectRestService.java
@@ -1,0 +1,45 @@
+package org.fusesource.restygwt.client.basic;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.fusesource.restygwt.client.DirectRestService;
+
+/**
+ * A service containing methods that return all primitive types.
+ */
+interface PrimitiveDirectRestService extends DirectRestService {
+    
+	@GET
+    @Path("/int")
+    int getInt();
+    
+    @GET
+    @Path("/long")
+    long getLong();
+    
+    @GET
+    @Path("/float")
+    float getFloat();
+    
+    @GET
+    @Path("/double")
+    double getDouble();
+    
+    @GET
+    @Path("/short")
+    short getShort();
+    
+    @GET
+    @Path("/byte")
+    byte getByte();
+    
+    @GET
+    @Path("/char")
+    char getChar();
+    
+    @GET
+    @Path("/boolean")
+    boolean getBoolean();
+    
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PrimitiveDirectRestService.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PrimitiveDirectRestService.java
@@ -9,37 +9,37 @@ import org.fusesource.restygwt.client.DirectRestService;
  * A service containing methods that return all primitive types.
  */
 interface PrimitiveDirectRestService extends DirectRestService {
-    
-	@GET
+
+    @GET
     @Path("/int")
     int getInt();
-    
+
     @GET
     @Path("/long")
     long getLong();
-    
+
     @GET
     @Path("/float")
     float getFloat();
-    
+
     @GET
     @Path("/double")
     double getDouble();
-    
+
     @GET
     @Path("/short")
     short getShort();
-    
+
     @GET
     @Path("/byte")
     byte getByte();
-    
+
     @GET
     @Path("/char")
     char getChar();
-    
+
     @GET
     @Path("/boolean")
     boolean getBoolean();
-    
+
 }


### PR DESCRIPTION
In addition to skipping the return statement for void methods, also
check for primitives and return the default uninitialized value.

This fixes issue #280.