### PR TITLE
Issue 283: Fixed JsonIgnore handling with sub class overrides

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -229,7 +229,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                     getLogger().log(DEBUG, "Only assignable classes are allowed: " + possibleType.clazz.getParameterizedQualifiedSourceName() + " is not assignable to: " + classType.getParameterizedQualifiedSourceName());
                     continue;
                 }
-                
+
                 if (!isLeaf) {
                     // Generate a decoder for each possible type
                     p("if(value.getClass().getName().equals(\"" + possibleType.clazz.getQualifiedBinaryName() + "\"))");

--- a/restygwt/src/test/java/org/fusesource/restygwt/GwtCompleteTestSuite.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/GwtCompleteTestSuite.java
@@ -44,6 +44,7 @@ import org.fusesource.restygwt.client.basic.TimeoutTestGwt;
 import org.fusesource.restygwt.client.cache.VolatileQueueableCacheStorageTestGwt;
 import org.fusesource.restygwt.client.codec.EncoderDecoderTestGwt;
 import org.fusesource.restygwt.client.codec.InnerClassesEncoderDecoderTestGwt;
+import org.fusesource.restygwt.client.codec.JsonIgnoreEncoderTestGwt;
 import org.fusesource.restygwt.client.codec.MapInRestServiceEncoderDecoderTestGwt;
 import org.fusesource.restygwt.client.codec.PolymorphicEncoderDecoderTestGwt;
 import org.fusesource.restygwt.client.complex.AutodetectPlainTextStringEncoderDecoderTestGwt;
@@ -85,6 +86,7 @@ public class GwtCompleteTestSuite extends TestCase {
         suite.addTestSuite(MapInRestServiceEncoderDecoderTestGwt.class);
         suite.addTestSuite(EncoderDecoderTestGwt.class);
         suite.addTestSuite(PolymorphicEncoderDecoderTestGwt.class);
+        suite.addTestSuite(JsonIgnoreEncoderTestGwt.class);
 
         suite.addTestSuite(FlakyTestGwt.class);
         suite.addTestSuite(TimeoutTestGwt.class);

--- a/restygwt/src/test/java/org/fusesource/restygwt/JsonIgnoreEncoderTestGwt.gwt.xml
+++ b/restygwt/src/test/java/org/fusesource/restygwt/JsonIgnoreEncoderTestGwt.gwt.xml
@@ -1,0 +1,43 @@
+<!--
+
+    Copyright (C) 2009-2015 the original author or authors.
+    See the notice.md file distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<module>
+    <inherits name='com.google.gwt.user.User' />
+    <inherits name='com.google.gwt.logging.Logging'/>
+    <inherits name='org.fusesource.restygwt.RestyGWT'/>
+
+    <!-- Logging Configuration -->
+    <set-property name="gwt.logging.enabled" value="TRUE"/>
+    <set-property name="gwt.logging.logLevel" value="ALL"/>
+
+    <source path='client'/>
+
+    <!-- seen at http://code.google.com/p/google-web-toolkit/source/browse/trunk/user/src/com/google/gwt/junit/JUnit.gwt.xml?r=5779 -->
+    <inherits name="com.google.gwt.benchmarks.Benchmarks"/>
+    <replace-with class="com.google.gwt.core.client.impl.StackTraceCreator.CollectorEmulated">
+        <when-type-is class="com.google.gwt.core.client.impl.StackTraceCreator.Collector" />
+        <none>
+            <when-property-is name="user.agent" value="gecko" />
+            <when-property-is name="user.agent" value="gecko1_8" />
+            <when-property-is name="user.agent" value="opera" />
+        </none>
+    </replace-with>
+
+</module>

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/JsonIgnoreEncoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/JsonIgnoreEncoderTestGwt.java
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2009-2015 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.fusesource.restygwt.client.codec;
 
 import org.fusesource.restygwt.client.JsonEncoderDecoder;

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/JsonIgnoreEncoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/JsonIgnoreEncoderTestGwt.java
@@ -1,0 +1,107 @@
+package org.fusesource.restygwt.client.codec;
+
+import org.fusesource.restygwt.client.JsonEncoderDecoder;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.json.client.JSONValue;
+import com.google.gwt.junit.client.GWTTestCase;
+
+public class JsonIgnoreEncoderTestGwt extends GWTTestCase {
+
+    @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "@type")
+    @JsonSubTypes({ @Type(Thing.class), @Type(SubThing.class) })
+    @JsonTypeName("thing")
+    public static class Thing {
+
+        private String name;
+        private String bar;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @JsonIgnore
+        public String getBar() {
+            return bar;
+        }
+
+        public void setBar(String bar) {
+            this.bar = bar;
+        }
+
+        @JsonIgnore
+        public String getFoo() {
+            return "foo";
+        }
+    }
+
+    @JsonTypeName("subthing")
+    public static class SubThing extends Thing {
+
+        private String foo;
+
+        @Override
+        @JsonIgnore(false)
+        public String getBar() {
+            return super.getBar();
+        }
+
+        @Override
+        @JsonIgnore(false)
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+    }
+
+    public interface ThingCodec extends JsonEncoderDecoder<Thing> {
+    }
+
+    @Override
+    public String getModuleName() {
+        return "org.fusesource.restygwt.JsonIgnoreEncoderTestGwt";
+    }
+
+    public void testEncodeJsonIgnoreTrueWithFieldDefinedInChild() {
+        ThingCodec codec = GWT.create(ThingCodec.class);
+
+        Thing thing = new Thing();
+
+        JSONValue thingJson = codec.encode(thing);
+        assertNull(thingJson.isObject().get("foo"));
+    }
+
+    public void testEncodeJsonIgnoreFalseWithFieldDefinedInChild() {
+        ThingCodec codec = GWT.create(ThingCodec.class);
+
+        SubThing thing = new SubThing();
+        thing.setFoo("foo");
+
+        JSONValue thingJson = codec.encode(thing);
+        assertEquals(thing.getFoo(), thingJson.isObject().get("foo").isString().stringValue());
+    }
+
+    public void testEncodeJsonIgnoreFalseWithFieldDefinedInParent() {
+        ThingCodec codec = GWT.create(ThingCodec.class);
+
+        SubThing thing = new SubThing();
+        thing.setBar("bar");
+
+        JSONValue thingJson = codec.encode(thing);
+        assertEquals(thing.getBar(), thingJson.isObject().get("bar").isString().stringValue());
+    }
+}


### PR DESCRIPTION
This is a fix for https://github.com/resty-gwt/resty-gwt/issues/283

added methods to help decide if methods or fields should be ignored base on JsonIgore or XmlTransient.
fixed issue with just checking for the existence of JsonIgnore vs looking at its value.
fixed issue with getGetterName starting with the enclosingType of the field instead of the subtype actually being used. This prevented annotation overrides being defined on subclass methods.
updated to always use AnnotationUtil.getAnnotation when finding JsonIgnore or XmlTransient annotations.