### PR TITLE
Always encode path params, even if they are URLs

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -393,8 +393,7 @@ public class RestServiceClassCreator extends BaseSourceCreator {
     private String pathExpression(String pathExpression, JParameter arg, PathParam paramPath) {
         String expr = toStringExpression(arg);
         return pathExpression.replaceAll(Pattern.quote("{" + paramPath.value()) + "(\\s*:\\s*(.)+)?\\}",
-               "\"+(" + expr + "== null? null : ((\"\" + " + expr +").startsWith(\"http\") ? " + expr +
-               " : com.google.gwt.http.client.URL.encodePathSegment(" + expr + ")))+\"");
+                "\"+(" + expr + "== null? null : com.google.gwt.http.client.URL.encodePathSegment(" + expr + "))+\"");
     }
 
     void writeOptions(Options options, Options classOptions) {

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PathParamTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PathParamTestGwt.java
@@ -139,11 +139,13 @@ public class PathParamTestGwt extends GWTTestCase {
         delayTestFinish(10000);
     }
 
+    /**
+     * Ensure that path parameters that are absolute URLs are URL encoded. 
+     */
     public void testAbsolute() {
-
-        service.absolute(GWT.getModuleBaseURL() + "echo/somewhere", echoMethodCallback("/somewhere") );
+        String absoluteUrl = "http://host:port/echo/somewhere";
+        service.absolute(absoluteUrl, echoMethodCallback("/" + absoluteUrl) );
         delayTestFinish(10000);
-
     }
 
 }


### PR DESCRIPTION
If a path param is not encoded then it may not be properly treated as a
single component of the path when it arrives at the server.

This commit addresses issue #294