### PR TITLE
Support string return values in DirectRestServices

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
@@ -20,6 +20,7 @@ package org.fusesource.restygwt.rebind;
 import java.lang.annotation.Annotation;
 
 import org.fusesource.restygwt.client.RestService;
+import org.fusesource.restygwt.client.TextCallback;
 import org.fusesource.restygwt.rebind.util.AnnotationCopyUtil;
 import org.fusesource.restygwt.rebind.util.AnnotationUtils;
 import org.fusesource.restygwt.rebind.util.OnceFirstIterator;
@@ -31,6 +32,7 @@ import com.google.gwt.core.ext.typeinfo.JClassType;
 import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.core.ext.typeinfo.JParameter;
 import com.google.gwt.core.ext.typeinfo.JPrimitiveType;
+import com.google.gwt.core.ext.typeinfo.JType;
 import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
 
 /**
@@ -78,11 +80,17 @@ public class DirectRestServiceInterfaceClassCreator extends DirectRestBaseSource
     }
 
     private String getMethodCallback(JMethod method) {
-        if (method.getReturnType().isPrimitive() != null) {
-            JPrimitiveType primitiveType = method.getReturnType().isPrimitive();
-            return "org.fusesource.restygwt.client.MethodCallback<" + primitiveType.getQualifiedBoxedSourceName() + "> callback";
+        String callbackType;
+        JType returnType = method.getReturnType();
+        if (returnType.isPrimitive() != null) {
+            JPrimitiveType primitiveType = returnType.isPrimitive();
+            callbackType = "org.fusesource.restygwt.client.MethodCallback<" + primitiveType.getQualifiedBoxedSourceName() + ">";
+        } else if (returnType.getQualifiedSourceName().equals(String.class.getName())) {
+            callbackType = TextCallback.class.getName();
+        } else {
+            callbackType = "org.fusesource.restygwt.client.MethodCallback<" + returnType.getParameterizedQualifiedSourceName() + ">";
         }
-        return "org.fusesource.restygwt.client.MethodCallback<" + method.getReturnType().getParameterizedQualifiedSourceName() + "> callback";
+        return callbackType + " callback";
     }
 
     private String getAnnotationsAsString(Annotation[] annotations) {

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectExampleService.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectExampleService.java
@@ -36,5 +36,9 @@ public interface DirectExampleService extends DirectRestService {
 
     @POST @Path("/store")
     void storeDto(ExampleDto exampleDto);
+
+    @GET @Path("/string")
+    String getString();
+
 }
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/basic/DirectServiceTestGwtServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/basic/DirectServiceTestGwtServlet.java
@@ -32,6 +32,7 @@ public class DirectServiceTestGwtServlet extends HttpServlet {
 
     String EMPTY_RESPONSE = "";
     String THREE_ELEMENT_LIST = "[{name:'1'},{name:'2'},{name:'3'}]";
+    String STRING_RESPONSE = "a string";
 
     @Override
     protected void doGet(HttpServletRequest request,
@@ -39,6 +40,8 @@ public class DirectServiceTestGwtServlet extends HttpServlet {
 
         if (request.getRequestURI().endsWith("/api/list")) {
             response.getWriter().print(THREE_ELEMENT_LIST);
+        } else if (request.getRequestURI().endsWith("/api/string")) {
+        	response.getWriter().print(STRING_RESPONSE);
         } else {
             throw new IllegalArgumentException("Invalid servlet path called by service: " + request.getRequestURI());
         }


### PR DESCRIPTION
Require TextCallback to be used when a DirectRestService method returns a string, which prevents the string from being interpreted as a JSON string which it probably is not.

This commit addresses issue #296