### PR TITLE
Deserialize BigDecimal from JSON string (containing a number)

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -374,11 +374,20 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
     // /////////////////////////////////////////////////////////////////
 
     static public BigDecimal toBigDecimal(JSONValue value) {
-        JSONNumber number = value.isNumber();
-        if (number == null) {
-            throw new DecodingException("Expected a json number, but was given: " + value);
+    	JSONNumber number = value.isNumber();
+    	if (number != null) {
+    		return new BigDecimal(number.toString());
+    	}
+        
+        JSONString string = value.isString();
+        if (string != null) {
+            try {
+            	new BigDecimal(value.toString());
+            } catch (NumberFormatException e) {
+            }
         }
-        return new BigDecimal(value.toString());
+        
+        throw new DecodingException("Expected a json number, but was given: " + value);
     }
 
     static public double toDouble(JSONValue value) {

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -382,7 +382,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         JSONString string = value.isString();
         if (string != null) {
             try {
-            	return new BigDecimal(value.toString());
+            	return new BigDecimal(string.stringValue());
             } catch (NumberFormatException e) {
             }
         }

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -382,7 +382,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
         JSONString string = value.isString();
         if (string != null) {
             try {
-            	new BigDecimal(value.toString());
+            	return new BigDecimal(value.toString());
             } catch (NumberFormatException e) {
             }
         }


### PR DESCRIPTION
BigDecimal is serialized to JSON string (as it should be), however deserializer accepted only numbers. This fix will check for number, either in json number or json string.