### PR TITLE
Split value of @Consumes annotation

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -603,6 +603,10 @@ public class RestServiceClassCreator extends BaseSourceCreator {
                 Consumes consumesAnnotation = findAnnotationOnMethodOrEnclosingType(method, Consumes.class);
                 if (consumesAnnotation != null) {
                     contentTypeHeaderValue = consumesAnnotation.value()[0];
+                    int split = contentTypeHeaderValue.indexOf(',');
+                    if (split > 0) {
+                        contentTypeHeaderValue = contentTypeHeaderValue.substring(0, split).trim();
+                    }
                     p("__method.header(" + RESOURCE_CLASS + ".HEADER_CONTENT_TYPE, " + wrap(contentTypeHeaderValue) + ");");
                }
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/complex/StringEncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/complex/StringEncoderDecoderTestGwt.java
@@ -75,7 +75,7 @@ public class StringEncoderDecoderTestGwt extends GWTTestCase {
         void getAsPlainText(TextCallback callback);
 
         @POST
-        @Consumes(MediaType.APPLICATION_JSON)
+        @Consumes(MediaType.APPLICATION_JSON + ", application/vnd.fusesource+json")
         void setAsJson(String text, MethodCallback<Void> callback);
 
         @POST
@@ -163,7 +163,7 @@ public class StringEncoderDecoderTestGwt extends GWTTestCase {
             @Override
             public void onFailure(Method method, Throwable exception) {
                 if (exception.getCause() instanceof JSONException) {
-                    // Only for backward compatbility test
+                    // Only for backward compatibility test
                     finishTest();
                 }
 


### PR DESCRIPTION
If @Consumes specifies a comma-delimited list of accepted media types,
split the list and use the first entry.

This commit addresses issue #303.