### PR TITLE
Fully qualify return type for generated decode method

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -423,7 +423,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
             return;
         }
 
-        p("public " + source.getName() + " decode(" + JSON_VALUE_CLASS + " value) {").i(1);
+        p("public " + source.getParameterizedQualifiedSourceName() + " decode(" + JSON_VALUE_CLASS + " value) {").i(1);
         {
             p("if( value == null || value.isNull()!=null ) {").i(1);
             {


### PR DESCRIPTION
When generating an EncoderDecoder source file use fully-qualified type
names.

This commit fixes issue #305.