### PR TITLE
Decoder will be generated, when possible type is more then one. Fix #292

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderClassCreator.java
@@ -230,7 +230,7 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                     continue;
                 }
 
-                if (!isLeaf) {
+                if (!isLeaf && possibleTypes.size() > 1) {
                     // Generate a decoder for each possible type
                     p("if(value.getClass().getName().equals(\"" + possibleType.clazz.getQualifiedBinaryName() + "\"))");
                     p("{");
@@ -355,12 +355,12 @@ public class JsonEncoderDecoderClassCreator extends BaseSourceCreator {
                         p("return rc;");
                     }
                 }
-                if (!isLeaf) {
+                if (!isLeaf && possibleTypes.size() > 1) {
                     p("}");
                 }
             }
 
-            if (!isLeaf) {
+            if (!isLeaf && possibleTypes.size() > 1) {
                 // Shouldn't get called
                 p("return null;");
             }

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/codec/EncoderDecoderTestGwt.java
@@ -1248,4 +1248,39 @@ public class EncoderDecoderTestGwt extends GWTTestCase {
         assertEquals("{\"xValue\":1, \"myValue\":3}", json.toString());
     }
 
+	static class ClassWithSubclass {
+
+		private String name = "Max";
+
+		String getName() {
+			return name;
+		}
+
+		void setName(String a) {
+			this.name = a;
+		}
+
+	}
+
+	static class SubclassWithoutEncoderDecoder extends ClassWithSubclass {
+
+		String getName() {
+			return super.getName() + " --> subclass";
+		}
+
+	}
+
+	static interface ClassWithSubclassCodec extends JsonEncoderDecoder<ClassWithSubclass> {
+	}
+
+	public void testSubclassCanBeEncodedBySuperclassEncoder() {
+		ClassWithSubclassCodec codec = GWT.create(ClassWithSubclassCodec.class);
+
+		SubclassWithoutEncoderDecoder subclassWithoutEncoderDecoder = new SubclassWithoutEncoderDecoder();
+		JSONValue json = codec.encode(subclassWithoutEncoderDecoder);
+		assertEquals("Max --> subclass", json.isObject().get("name").isString().stringValue());
+		ClassWithSubclass roundTrip = codec.decode(json);
+		assertEquals("Max --> subclass", roundTrip.getName());
+	}
+	
 }


### PR DESCRIPTION
The commit 970d245 provides the feature to generate a decoder, when the quantity of subtypes is more then one.

This is useful if you create a subclass of objects, that are not relevant for the encoding process. Our use case is Proxy Objects that add behavior and event bus integration to the Pojos.

See issue #292