### PR TITLE
Added the feature in RestServiceClassCreator to work with public getter-Methods and public fields in case of using attribute annotations. Fix #291

### DIFF
--- a/restygwt/src/test/java/org/fusesource/restygwt/AttributeTestGwt.gwt.xml
+++ b/restygwt/src/test/java/org/fusesource/restygwt/AttributeTestGwt.gwt.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (C) 2009-2012 the original author or authors.
+    See the notice.md file distributed with this work for additional
+    information regarding copyright ownership.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<module>
+	<inherits name='com.google.gwt.user.User' />
+	<inherits name='com.google.gwt.logging.Logging'/>
+	<inherits name='org.fusesource.restygwt.RestyGWT'/>
+	<servlet path='/attribute/*' class='org.fusesource.restygwt.server.basic.AttributeTestGwtServlet' />
+
+	<source path='client'/>
+	<source path='example/client'/>
+</module>

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/AttributeDTO.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/AttributeDTO.java
@@ -1,0 +1,24 @@
+package org.fusesource.restygwt.client.basic;
+
+public class AttributeDTO {
+
+	public Long publicId;
+	private Long privateId;
+	private String path;
+
+	public Long getPrivateId() {
+		return privateId;
+	}
+
+	public void setPrivateId(Long privateId) {
+		this.privateId = privateId;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/AttributeTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/AttributeTestGwt.java
@@ -1,0 +1,109 @@
+package org.fusesource.restygwt.client.basic;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.junit.client.GWTTestCase;
+import org.fusesource.restygwt.client.Attribute;
+import org.fusesource.restygwt.client.Method;
+import org.fusesource.restygwt.client.MethodCallback;
+import org.fusesource.restygwt.client.Resource;
+import org.fusesource.restygwt.client.RestService;
+import org.fusesource.restygwt.client.RestServiceProxy;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * @author Thomas Cybulski
+ */
+public class AttributeTestGwt extends GWTTestCase {
+
+	private AttributeTestRestService service;
+
+	@Override
+	public String getModuleName() {
+		return "org.fusesource.restygwt.AttributeTestGwt";
+	}
+
+	interface AttributeTestRestService extends RestService {
+
+		@POST
+		@Path("/save")
+		void savePublicAttribute(@Attribute("publicId") AttributeDTO instance, MethodCallback<AttributeDTO> callback);
+
+
+		@POST
+		@Path("/save")
+		void savePrivateAttribute(@Attribute("privateId") AttributeDTO instance, MethodCallback<AttributeDTO> callback);
+	}
+
+	class AttributeDTOMethodCallback implements MethodCallback<AttributeDTO> {
+
+		private final String path;
+
+		AttributeDTOMethodCallback(String path) {
+			this.path = path;
+		}
+
+		@Override
+		public void onSuccess(Method method, AttributeDTO response) {
+
+			assertEquals(response.getPath(), path);
+
+			finishTest();
+
+		}
+
+		@Override
+		public void onFailure(Method method, Throwable exception) {
+
+			fail();
+
+		}
+	}
+
+	@Override
+	protected void gwtSetUp() throws Exception {
+		super.gwtSetUp();
+		service = GWT.create(AttributeTestRestService.class);
+		Resource resource = new Resource(GWT.getModuleBaseURL() + "attribute");
+		((RestServiceProxy) service).setResource(resource);
+	}
+
+
+	public void testSaveWithInstance() {
+
+		AttributeDTO dto = new AttributeDTO();
+		dto.setPath("/save");
+
+		service.savePublicAttribute(dto, new AttributeDTOMethodCallback("/save"));
+
+	}
+
+	public void testSaveWithNull() {
+
+		service.savePublicAttribute(null, new MethodCallback<AttributeDTO>() {
+
+			@Override
+			public void onFailure(Method method, Throwable exception) {
+
+				fail();
+
+			}
+
+			@Override
+			public void onSuccess(Method method, AttributeDTO response) {
+
+				assertFalse(response.getPath().contains("path"));
+
+			}
+		});
+
+	}
+
+	public void gwtTearDown() {
+
+		// wait... we are in async testing...
+		delayTestFinish(10000);
+
+	}
+}

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/AttributeTestGwtServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/AttributeTestGwtServlet.java
@@ -1,0 +1,34 @@
+package org.fusesource.restygwt.server.basic;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.fusesource.restygwt.client.basic.AttributeDTO;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * just echos back the request path and the request parameters.
+ *
+ * @author Thomas Cybulski
+ */
+public class AttributeTestGwtServlet extends HttpServlet {
+
+	@Override
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		doAttributeRequest(request, response);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void doAttributeRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		AttributeDTO dto = new AttributeDTO();
+		dto.setPath(request.getPathInfo());
+
+		ObjectMapper mapper = new ObjectMapper();
+		response.setContentType("application/json");
+		mapper.writeValue(response.getOutputStream(), dto);
+	}
+
+}


### PR DESCRIPTION
Enhanced the toStringExpression in RestServiceClassCreator to work with public getter-Methods and public fields.

See issue #291