### PR TITLE
Fix encoding maps, collections and arrays when Defaults.doesIgnoreJsonNulls() is true

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -714,7 +714,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
             AbstractJsonEncoderDecoder<KeyType> keyEncoder, AbstractJsonEncoderDecoder<ValueType> valueEncoder,
             Style style) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
 
         switch (style) {
@@ -761,7 +761,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(Map<String, Type> value, AbstractJsonEncoderDecoder<Type> encoder, Style style) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
 
         switch (style) {
@@ -793,7 +793,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(Collection<Type> value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -805,7 +805,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(Type[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -817,7 +817,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(short[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -829,7 +829,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(int[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -841,7 +841,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(long[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -853,7 +853,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(float[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -865,7 +865,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
     
     static public <Type> JSONValue toJSON(double[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -877,7 +877,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(boolean[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -889,7 +889,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(char[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         JSONArray rc = new JSONArray();
         int i = 0;
@@ -901,7 +901,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     static public <Type> JSONValue toJSON(byte[] value, AbstractJsonEncoderDecoder<Type> encoder) {
         if (value == null) {
-            return JSONNull.getInstance();
+            return getNullType();
         }
         
         if (Defaults.isByteArraysToBase64()) {

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractNestedJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractNestedJsonEncoderDecoder.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.fusesource.restygwt.client.Json.Style;
 
+import com.google.gwt.json.client.JSONNull;
 import com.google.gwt.json.client.JSONValue;
 
 public abstract class AbstractNestedJsonEncoderDecoder<E, F, G> extends AbstractJsonEncoderDecoder<E> {
@@ -36,7 +37,7 @@ public abstract class AbstractNestedJsonEncoderDecoder<E, F, G> extends Abstract
             @Override
             public JSONValue encode(T[] value)
                     throws EncodingException {
-                return toJSON(value, nested);
+                return value != null ? toJSON(value, nested) : JSONNull.getInstance();
             }
 
             @SuppressWarnings("unchecked")
@@ -55,7 +56,7 @@ public abstract class AbstractNestedJsonEncoderDecoder<E, F, G> extends Abstract
             @Override
             public JSONValue encode(Collection<T> value)
                     throws EncodingException {
-                return toJSON((T[])value.toArray(), nested);
+                return value != null ? toJSON((T[])value.toArray(), nested) : JSONNull.getInstance();
             }
 
             @Override
@@ -73,7 +74,7 @@ public abstract class AbstractNestedJsonEncoderDecoder<E, F, G> extends Abstract
             @Override
             public JSONValue encode(List<T> value)
                     throws EncodingException {
-                return toJSON((T[])value.toArray(), nested);
+                return value != null ? toJSON((T[])value.toArray(), nested) : JSONNull.getInstance();
             }
 
             @Override
@@ -90,7 +91,7 @@ public abstract class AbstractNestedJsonEncoderDecoder<E, F, G> extends Abstract
             @Override
             public JSONValue encode(Set<T> value)
                     throws EncodingException {
-                return toJSON(value, nested);
+                return value != null ? toJSON(value, nested) : JSONNull.getInstance();
             }
 
             @Override
@@ -107,7 +108,7 @@ public abstract class AbstractNestedJsonEncoderDecoder<E, F, G> extends Abstract
             @Override
             public JSONValue encode(Map<String, T> value)
                     throws EncodingException {
-                return toJSON(value, nested, style);
+                return value != null ? toJSON(value, nested, style) : JSONNull.getInstance();
             }
 
             @Override
@@ -125,7 +126,7 @@ public abstract class AbstractNestedJsonEncoderDecoder<E, F, G> extends Abstract
             @Override
             public JSONValue encode(Map<T, S> value)
                     throws EncodingException {
-                return toJSON(value, nested, second, style);
+                return value != null ? toJSON(value, nested, second, style) : JSONNull.getInstance();
             }
 
             @Override


### PR DESCRIPTION
Defaults.ignoreJsonNulls() is ignored when encoding null map, collection or array