### PR TITLE
Fixes support for regex in URI templates

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -392,7 +392,7 @@ public class RestServiceClassCreator extends BaseSourceCreator {
 
     private String pathExpression(String pathExpression, JParameter arg, PathParam paramPath) throws UnableToCompleteException {
         String expr = toStringExpression(arg);
-        return pathExpression.replaceAll(Pattern.quote("{" + paramPath.value()) + "(\\s*:\\s*(.)+)?\\}",
+        return pathExpression.replaceAll(Pattern.quote("{" + paramPath.value()) + "(\\s*:\\s*([^{}][^{}]*))*\\}",
                 "\"+(" + expr + "== null? null : com.google.gwt.http.client.URL.encodePathSegment(" + expr + "))+\"");
     }
 

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PathParamTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/PathParamTestGwt.java
@@ -63,6 +63,9 @@ public class PathParamTestGwt extends GWTTestCase {
         @GET @Path("/get/{id : \\d+}")
         void getRegex(@PathParam(value = "id") Integer i, MethodCallback<Echo> callback);
 
+        @GET @Path("/get/{id : \\d+}/things/{thing: \\d+}")
+        void getRegexMultiParams(@PathParam(value = "id") Integer i, @PathParam(value = "thing") Integer t, MethodCallback<Echo> callback);
+
         @GET @Path("{url}")
         void absolute(@PathParam(value = "url") String u, MethodCallback<Echo> callback);
     }
@@ -136,6 +139,11 @@ public class PathParamTestGwt extends GWTTestCase {
 
     public void testGetWithIntRegex() {
         service.getRegex(123, echoMethodCallback("/get/123"));
+        delayTestFinish(10000);
+    }
+
+    public void testGetWithIntsRegex() {
+        service.getRegexMultiParams(123, 456, echoMethodCallback("/get/123/things/456"));
         delayTestFinish(10000);
     }
 


### PR DESCRIPTION
Fixes a bug in the support for regex in URI templates that I proposed in #237

If there were multiple path params (with or without regexes) this would break everything as only the first param would have been replaced and the end of the path would have been stripped

This is a nasty and dangerous bug, particularly if one has `@DELETE @Path("/{id})` and `@DELETE @Path("/{id}/things/{tId}")` as it would call the first one in any cases...

We had the bug, that's how I detected it. I'm sorry that I introduced such a dangerous thing in RestyGWT.

The new regex is taken from [Errai JAX-RS](https://github.com/errai/errai/blob/master/errai-jaxrs/errai-jaxrs-client/src/main/java/org/jboss/errai/enterprise/rebind/JaxrsResourceMethodParameters.java#L58) and this one works. I've added a test to confirm that subsequent path params are always replaced as needed.