### PR TITLE
Fixed a bug in type identifier generation

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractJsonEncoderDecoder.java
@@ -711,7 +711,7 @@ abstract public class AbstractJsonEncoderDecoder<T> implements JsonEncoderDecode
 
     // TODO(sbeutel): new map method to handle other key values than String
     static public <KeyType, ValueType> JSONValue toJSON(Map<KeyType, ValueType> value,
-            AbstractJsonEncoderDecoder<KeyType> keyEncoder, AbstractJsonEncoderDecoder<ValueType> valueEncoder,
+            AbstractJsonEncoderDecoder<? super KeyType> keyEncoder, AbstractJsonEncoderDecoder<? super ValueType> valueEncoder,
             Style style) {
         if (value == null) {
             return getNullType();

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/BaseSourceCreator.java
@@ -89,7 +89,7 @@ public abstract class BaseSourceCreator extends AbstractSourceCreator {
 			for(JClassType type : ptype.getTypeArgs())
 			{
 				builder.append("__");
-				builder.append(type.getParameterizedQualifiedSourceName().replace('.', '_').replace("<", "__").replace(">", "__"));
+				builder.append(type.getParameterizedQualifiedSourceName().replace('.', '_').replace("<", "__").replace(">", "__").replace(",", "_").replace(" ", "_"));
 			}
 			this.shortName = getName( source ) + builder.toString() + suffix;
         }


### PR DESCRIPTION
Encoder/decoder type names generated from getParameterizedQualifiedSourceName were invalid if the type included more than one parameter, e.g. A\<B, C>. The commas and the spaces were not properly replaced with underscore resulting in compile errors in the generated code. 

Also a small improvement to the map encoder to make it accept contravariant encoders for key/value types. This is useful to encode, for instance, Map\<String, PList> where PList is a custom list implementation that satisfies the standard List interface.