### PR TITLE
janitorial: eclipse warnings

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceClassCreator.java
@@ -1,6 +1,5 @@
 package org.fusesource.restygwt.rebind;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/DirectRestServiceInterfaceClassCreator.java
@@ -87,9 +87,8 @@ public class DirectRestServiceInterfaceClassCreator extends DirectRestBaseSource
         final String returnType = method.getReturnType().getParameterizedQualifiedSourceName();
         if (isOverlayMethod(method)) {
             return "org.fusesource.restygwt.client.OverlayCallback<" + returnType + "> callback";
-        } else {
-            return "org.fusesource.restygwt.client.MethodCallback<" + returnType + "> callback";
         }
+        return "org.fusesource.restygwt.client.MethodCallback<" + returnType + "> callback";
     }
 
     private String getAnnotationsAsString(Annotation[] annotations) {

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/EncoderDecoderLocatorFactory.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/EncoderDecoderLocatorFactory.java
@@ -9,9 +9,6 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 public class EncoderDecoderLocatorFactory {
 
 
-	private static JsonEncoderDecoderInstanceLocator restyGwtInstanceLocator;
-	private static GwtJacksonEncoderDecoderInstanceLocator gwtJacksonInstanceLocator;
-
 	public static final String USE_GWT_JACKSON_ENCODE_DECODER_PROPERTY_NAME = "restygwt.encodeDecode.useGwtJackson";
 
 	public static EncoderDecoderLocator getEncoderDecoderInstanceLocator(GeneratorContext context,
@@ -32,9 +29,8 @@ public class EncoderDecoderLocatorFactory {
 
 		if (useGwtJacksonDecoder) {
 			return getGwtJacksonInstance(context, logger);
-		} else {
-			return restyGwtInstance(context, logger);
 		}
+		return restyGwtInstance(context, logger);
 	}
 
 	private static EncoderDecoderLocator restyGwtInstance(GeneratorContext context, TreeLogger logger)

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/GwtJacksonEncoderDecoderClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/GwtJacksonEncoderDecoderClassCreator.java
@@ -96,7 +96,7 @@ public class GwtJacksonEncoderDecoderClassCreator extends BaseSourceCreator {
 		return composerFactory;
 	}
 
-	private void generateEncodeMethod(JClassType classType) throws UnableToCompleteException {
+	private void generateEncodeMethod(JClassType classType) {
 
 		p("public " + JSON_VALUE_CLASS + " encode(" + source.getParameterizedQualifiedSourceName() + " value) {").i(1);
 
@@ -126,7 +126,7 @@ public class GwtJacksonEncoderDecoderClassCreator extends BaseSourceCreator {
 		return method;
 	}
 
-	private void generateDecodeMethod(JClassType classType) throws UnableToCompleteException {
+	private void generateDecodeMethod(JClassType classType) {
 		p("public " + source.getParameterizedQualifiedSourceName() + " decode(" + JSON_VALUE_CLASS + " value) {").i(1);
 		{
 			p("if( value == null || value.isNull()!=null ) {").i(1);

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/GwtJacksonEncoderDecoderInstanceLocator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/GwtJacksonEncoderDecoderInstanceLocator.java
@@ -30,7 +30,7 @@ import com.google.gwt.core.ext.typeinfo.JType;
  * 
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
-public class GwtJacksonEncoderDecoderInstanceLocator extends JsonEncoderDecoderInstanceLocator implements EncoderDecoderLocator {
+public class GwtJacksonEncoderDecoderInstanceLocator extends JsonEncoderDecoderInstanceLocator {
 
     
     public GwtJacksonEncoderDecoderInstanceLocator(GeneratorContext context, TreeLogger logger)

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/JsonEncoderDecoderInstanceLocator.java
@@ -410,6 +410,7 @@ public class JsonEncoderDecoderInstanceLocator implements EncoderDecoderLocator 
         return types;
     }
 
+    @Override
     public boolean isCollectionType(JClassType clazz) {
         return clazz != null
                 && (clazz.isAssignableTo(SET_TYPE) || clazz.isAssignableTo(LIST_TYPE) || clazz.isAssignableTo(MAP_TYPE) || clazz.isAssignableTo(COLLECTION_TYPE));

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/util/AnnotationCopyUtil.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/util/AnnotationCopyUtil.java
@@ -20,7 +20,6 @@ package org.fusesource.restygwt.rebind.util;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
-import java.util.regex.Pattern;
 
 /**
  * An utility class that gets a String representation of an annotation.


### PR DESCRIPTION
eclipse warns me about these. The only thing that stands out is the removal of two static variables

 - private static JsonEncoderDecoderInstanceLocator restyGwtInstanceLocator;
- private static GwtJacksonEncoderDecoderInstanceLocator gwtJacksonInstanceLocator;

I don't know if they are used in any magical way but the compilation is not broken.