### PR TITLE
Remove restriction to use  Interfaces as content parameter

### DIFF
--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/UI.gwt.xml
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/UI.gwt.xml
@@ -27,6 +27,7 @@
 
   <servlet path='/pizza-service/toppings' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
   <servlet path='/pizza-service/ping' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
+  <servlet path='/pizza-service/crusts' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
   <servlet path='/pizza-service' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
   <servlet path='/jsonp-service' class='org.fusesource.restygwt.examples.server.JsonpServlet'/>
   <servlet path='/test/method' class='org.fusesource.restygwt.examples.server.TestServlet'/>

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/CheesyCrust.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/CheesyCrust.java
@@ -1,0 +1,8 @@
+package org.fusesource.restygwt.examples.client;
+
+
+public class CheesyCrust implements Crust {
+    public String getName() {
+        return "cheesy";
+    }
+}

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/Crust.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/Crust.java
@@ -1,0 +1,10 @@
+package org.fusesource.restygwt.examples.client;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use=Id.CLASS, include=As.PROPERTY, property="class")
+public interface Crust {
+    String getName();
+}

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/PizzaService.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/PizzaService.java
@@ -21,6 +21,7 @@ package org.fusesource.restygwt.examples.client;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.OPTIONS;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -29,6 +30,7 @@ import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.RestService;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 
@@ -44,6 +46,11 @@ public interface PizzaService extends RestService {
     @Path("/toppings")
     @Produces( MediaType.APPLICATION_JSON )
     public void listToppings(MethodCallback<List<Topping>> callback);
+
+    @OPTIONS
+    @Path("/crusts")
+    @Produces( MediaType.APPLICATION_JSON )
+    public void getCurstPrices(Crust crust, MethodCallback<Map<Integer, Double>> callback);
 
     @DELETE
     @Path("/ping")

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/ThinCrust.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/ThinCrust.java
@@ -1,0 +1,9 @@
+package org.fusesource.restygwt.examples.client;
+
+public class ThinCrust implements Crust {
+
+	public String getName() {
+		return "thin";
+	}
+
+}

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/server/PizzaServlet.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/server/PizzaServlet.java
@@ -21,6 +21,8 @@ package org.fusesource.restygwt.examples.server;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -99,6 +101,31 @@ public class PizzaServlet extends HttpServlet {
 
             resp.setContentType(Resource.CONTENT_TYPE_JSON);
             mapper.writeValue(resp.getOutputStream(), toppings);
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+        } finally {
+            System.out.flush();
+            System.err.flush();
+        }
+    }
+
+    @Override
+    protected  void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        System.out.println("Processing Crust prices");
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+
+            Map<Integer, Double> prices = new HashMap<Integer, Double>();
+            prices.put(28, 1.5);
+            prices.put(32, 2.0);
+
+            StringWriter sw = new StringWriter();
+            mapper.writeValue(sw, prices);
+            System.out.println("Response: " + sw.toString());
+
+            resp.setContentType(Resource.CONTENT_TYPE_JSON);
+            mapper.writeValue(resp.getOutputStream(), prices);
 
         } catch (Throwable e) {
             e.printStackTrace();

--- a/restygwt/src/it/restygwt-example/src/test/java/org/fusesource/restygwt/examples/client/PizzaServiceUITestGWT.java
+++ b/restygwt/src/it/restygwt-example/src/test/java/org/fusesource/restygwt/examples/client/PizzaServiceUITestGWT.java
@@ -24,6 +24,7 @@ import org.fusesource.restygwt.client.MethodCallback;
 import com.google.gwt.core.client.GWT;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 
@@ -116,6 +117,27 @@ public class PizzaServiceUITestGWT extends UITestGWT {
             }
         });
 
+        delayTestFinish(2000);
+    }
+
+    public void testCrustPrices() {
+        Crust crust = new CheesyCrust();
+        // Initialize the pizza service..
+        PizzaService service = GWT.create(PizzaService.class);
+
+        service.getCurstPrices(crust, new MethodCallback<Map<Integer, Double>>(){
+            public void onSuccess(Method method, Map<Integer, Double> response) {
+                System.out.println(response);
+                assertNotNull(response);
+                assertEquals(2, response.size());
+                finishTest();
+            }
+            public void onFailure(Method method, Throwable exception) {
+                exception.printStackTrace();
+                fail(exception.getMessage());
+            }
+
+        });
         delayTestFinish(2000);
     }
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
@@ -149,7 +149,7 @@ public class PossibleTypesVisitor extends JsonTypeInfoIdVisitor<List<Subtype>, U
         final List<Subtype> possibleTypes = Lists.newArrayList();
         List<JClassType> resolvedSubtypes = Lists.newArrayList();
 
-        if (types != null) {
+        if (types != null && !types.isEmpty()) {
             for (JsonSubTypes.Type type : types) {
                 JClassType typeClass = BaseSourceCreator.find(type.value(), logger, context);
                 if (!isLeaf || classType.equals(typeClass))

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -657,13 +657,10 @@ public class RestServiceClassCreator extends BaseSourceCreator {
                 } else if (contentArg.getType() == DOCUMENT_TYPE) {
                     p("__method.xml(" + contentArg.getName() + ");");
                 } else {
-                    JClassType contentClass = contentArg.getType().isClass();
+                    JClassType contentClass = contentArg.getType().isClassOrInterface();
                     if (contentClass == null) {
-                        contentClass = contentArg.getType().isClassOrInterface();
-                        if (!locator.isCollectionType(contentClass)) {
-                            getLogger().log(ERROR, "Content argument must be a class.");
-                            throw new UnableToCompleteException();
-                        }
+                        getLogger().log(ERROR, "Content argument must be a class.");
+                        throw new UnableToCompleteException();
                     }
 
                     jsonAnnotation = getAnnotation(contentArg, Json.class);


### PR DESCRIPTION
RestyGWT does not accept intefaces as content parameter in Rest methods.
This commit removes this restriction as it works fine on the server (jackson) and on the client (gwt-jackson).