### PR TITLE
Add Test for #342

### DIFF
--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectExampleService.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectExampleService.java
@@ -25,6 +25,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -35,6 +37,9 @@ public interface DirectExampleService extends DirectRestService {
 
     @GET @Path("/list")
     List<ExampleDto> getExampleDtos(@QueryParam("id") String id);
+
+    @GET @Path("/date")
+    Long getDate(@QueryParam("date") Date date);
 
     @POST @Path("/store")
     void storeDto(ExampleDto exampleDto);

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
@@ -22,6 +22,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.junit.client.GWTTestCase;
 import org.fusesource.restygwt.client.*;
 
+import java.util.Date;
 import java.util.List;
 
 import javax.ws.rs.GET;
@@ -72,6 +73,30 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
                 fail(e.getMessage());
             }
         }).call(directExampleService).getExampleDtos("3");
+    }
+
+    public void testDateFormat() {
+        delayTestFinish(10000);
+        DirectExampleService directExampleService = GWT.create(DirectExampleService.class);
+
+        Resource resource = new Resource(GWT.getModuleBaseURL() + "api");
+        ((RestServiceProxy) directExampleService).setResource(resource);
+
+        Defaults.setDateFormat(null);
+
+        final Date date = new Date(1506224400000L);
+        REST.withCallback(new MethodCallback<Long>() {
+            @Override
+            public void onSuccess(Method method, Long response) {
+                assertEquals(date.getTime(), response.longValue());
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(directExampleService).getDate(date);
     }
 
     public void testRegexPathParamCall() {

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/basic/DirectServiceTestGwtServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/basic/DirectServiceTestGwtServlet.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Date;
 
 /**
  * A servlet that just implements the services required for the direct service test.
@@ -37,7 +38,9 @@ public class DirectServiceTestGwtServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
 
-        if (request.getRequestURI().endsWith("/api/list")) {
+        if (request.getRequestURI().endsWith("/date")) {
+            response.getWriter().print(Long.parseLong(request.getParameter("date")));
+        } else if (request.getRequestURI().endsWith("/api/list")) {
             response.getWriter().print(THREE_ELEMENT_LIST);
         } else if (request.getRequestURI().matches(".+/\\d+")) {
             String url = request.getRequestURI();


### PR DESCRIPTION
Without the fix bc7139f , this Test failed because:

Actual URI:
/api/date?date=Sun+Sep+24+13%3A40%3A00+AEST+2017

Expected URI:
/api/date?date=1506224400000

Starting Jetty on port 0
   [WARN] /org.fusesource.restygwt.DirectRestServiceTestGwt.JUnit/api/date
java.lang.NumberFormatException: For input string: "Sun Sep 24 13:40:00 AEST 2017"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.parseLong(Long.java:631)
	at org.fusesource.restygwt.server.basic.DirectServiceTestGwtServlet.doGet(DirectServiceTestGwtServlet.java:42)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:735)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:686)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:501)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:137)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:557)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:231)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:428)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:193)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
	at org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:68)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
	at org.eclipse.jetty.server.Server.handle(Server.java:370)
	at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:489)
	at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:949)
	at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1011)
	at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:644)
	at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:235)
	at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:668)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:52)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)
	at java.lang.Thread.run(Thread.java:748)
[ERROR] 500 - GET /org.fusesource.restygwt.DirectRestServiceTestGwt.JUnit/api/date?date=Sun+Sep+24+13%3A40%3A00+AEST+2017 (10.10.10.252) 4029 bytes