### PR TITLE
Update resteasy dependencies to latest (3.1.4.Final)

### DIFF
--- a/restygwt/pom.xml
+++ b/restygwt/pom.xml
@@ -245,9 +245,9 @@
   </profiles>
 
   <properties>
+    <resteasy.version>3.1.4.Final</resteasy.version>
     <!-- we need to keep this in sync with gwt-jackson's dependencies -->
     <jackson.version>2.8.4</jackson.version>
-    <resteasy.version>2.3.4.Final</resteasy.version>
     <gwt.version>2.7.0</gwt.version>
   </properties>
 </project>


### PR DESCRIPTION
Also make it clear in pom.xml that resteasy doesn't require to be in sync with gwt-jackson's dependencies (gwt-jackson doesn't have any resteasy dependency)