### PR TITLE
Update resteasy dependencies to latest (3.0.24.Final)

### DIFF
--- a/restygwt/pom.xml
+++ b/restygwt/pom.xml
@@ -39,8 +39,8 @@
 
     <dependency>
       <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>1.1</version>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -245,9 +245,10 @@
   </profiles>
 
   <properties>
+    <!--Must stay on 3.0.x branch to be buildable with JDK7 (3.1.x branch requires JDK8).-->
+    <resteasy.version>3.0.24.Final</resteasy.version>
     <!-- we need to keep this in sync with gwt-jackson's dependencies -->
     <jackson.version>2.8.4</jackson.version>
-    <resteasy.version>2.3.4.Final</resteasy.version>
     <gwt.version>2.7.0</gwt.version>
   </properties>
 </project>

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/complex/string/StringEncoderDecoderTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/complex/string/StringEncoderDecoderTestGwt.java
@@ -18,6 +18,7 @@
 
 package org.fusesource.restygwt.client.complex.string;
 
+import org.fusesource.restygwt.client.FailedResponseException;
 import org.fusesource.restygwt.client.Method;
 import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.TextCallback;
@@ -69,7 +70,8 @@ public class StringEncoderDecoderTestGwt extends GWTTestCase {
 
             @Override
             public void onFailure(Method method, Throwable exception) {
-                if (400 == method.getResponse().getStatusCode() && "Wrong Format".equals(exception.getMessage())) {
+                if (400 == method.getResponse().getStatusCode() && exception instanceof FailedResponseException &&
+                        "Wrong Format".equals(((FailedResponseException) exception).getResponse().getText())) {
                     finishTest();
                 } else {
                     fail();

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/StringEncoderDecoderServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/StringEncoderDecoderServlet.java
@@ -49,7 +49,7 @@ public class StringEncoderDecoderServlet extends HttpServletDispatcher {
 
         /**
          * Method to test POST with {@code @Consumes(MediaType.APPLICATION_JSON)}.
-         * 
+         *
          * @throws BadRequestException
          *             For restygwt <= 2.0.3 or plain text autodetection set to {@code false} because it sends every String as plain text
          */
@@ -72,10 +72,10 @@ public class StringEncoderDecoderServlet extends HttpServletDispatcher {
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
 
-        final ResteasyProviderFactory providerFactory = (ResteasyProviderFactory) config.getServletContext().getAttribute(ResteasyProviderFactory.class.getName());
+        ResteasyProviderFactory providerFactory = servletContainerDispatcher.getDispatcher().getProviderFactory();
         providerFactory.registerProvider(JsonStringProvider.class);
 
-        final Registry registry = (Registry) config.getServletContext().getAttribute(Registry.class.getName());
+        Registry registry = servletContainerDispatcher.getDispatcher().getRegistry();
         registry.addPerRequestResource(StringsImpl.class, "/org.fusesource.restygwt.StringEncoderDecoderTestGwt.JUnit");
         registry.addPerRequestResource(StringsImpl.class, "/org.fusesource.restygwt.StringEncoderDecoderAutodetectPlainTextTestGwt.JUnit");
     }


### PR DESCRIPTION
Must stay on 3.0.x branch to be buildable with JDK7 (3.1.x branch requires JDK8).

Also make it clear in pom.xml that resteasy doesn't require to be in sync with gwt-jackson's dependencies (gwt-jackson doesn't have any resteasy dependency)