### PR TITLE
Update gwt-jackson to 0.15.0

### DIFF
--- a/restygwt/pom.xml
+++ b/restygwt/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.github.nmorel.gwtjackson</groupId>
             <artifactId>gwt-jackson</artifactId>
-            <version>0.14.2</version>
+            <version>0.15.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
It fixes:
- Incorrect serialisation of Map<> with a null value with JsonSerializationContext#serializeNulls == false
(see: https://github.com/nmorel/gwt-jackson/issues/125)

And it brings 2 new extensions:
- Objectify
- Remote Logging
(see: https://github.com/nmorel/gwt-jackson/pull/128)