### PR TITLE
#383 MediaType.TEXT_PLAIN - Empty String is converted to null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
 env:
   # - GWT_VERSION=2.8.0-beta1
   - GWT_VERSION=2.7.0
-  - GWT_VERSION=2.5.1
+  - GWT_VERSION=2.6.0
   
 script: mvn install -Dgwt.version=$GWT_VERSION
 matrix:

--- a/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractRequestCallback.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/AbstractRequestCallback.java
@@ -67,15 +67,18 @@ public abstract class AbstractRequestCallback<T> implements RequestCallback {
             callback
                     .onFailure(method, Defaults.getExceptionMapper().createFailedStatusException(method, response));
         } else {
+            if (getLogger() != null) {
+                getLogger().fine(
+                        "Received http response for request: " + method.builder.getHTTPMethod() + " " +
+                                method.builder.getUrl());
+            }
+            if (Response.SC_NO_CONTENT == response.getStatusCode()) {
+                callback.onSuccess(method, null);
+            }
             T value;
             try {
-                if (getLogger() != null) {
-                    getLogger().fine(
-                            "Received http response for request: " + method.builder.getHTTPMethod() + " " +
-                                    method.builder.getUrl());
-                }
                 String content = response.getText();
-                if (content != null && !content.isEmpty()) {
+                if (content != null) {
                     if (getLogger() != null) {
                         getLogger().finest(content);
                     }

--- a/restygwt/src/test/java/org/fusesource/restygwt/ResteasyGwtJacksonTestGwt.gwt.xml
+++ b/restygwt/src/test/java/org/fusesource/restygwt/ResteasyGwtJacksonTestGwt.gwt.xml
@@ -26,6 +26,7 @@
     <inherits name="com.github.nmorel.gwtjackson.GwtJackson"/>
 
     <set-property name="restygwt.encodeDecode.useGwtJackson" value="true"/>
+    <set-property name="restygwt.autodetect.plainText" value="true"/>
 
     <source path='client'/>
     <source path='example/client'/>

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/ResteasyGwtJacksonTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/ResteasyGwtJacksonTestGwt.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 import org.fusesource.restygwt.client.Method;
 import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.REST;
+import org.fusesource.restygwt.client.TextCallback;
 import org.fusesource.restygwt.client.complex.ResteasyService;
 
 public class ResteasyGwtJacksonTestGwt extends GWTTestCase {
@@ -82,7 +83,7 @@ public class ResteasyGwtJacksonTestGwt extends GWTTestCase {
         return "org.fusesource.restygwt.ResteasyGwtJacksonTestGwt";
     }
 
-    public void testGetString() {
+    public void testGetStringAnyString() {
         delayTestFinish(10000);
         ResteasyService resteasyService = GWT.create(ResteasyService.class);
 
@@ -101,7 +102,45 @@ public class ResteasyGwtJacksonTestGwt extends GWTTestCase {
         }).call(resteasyService).getString(name);
     }
 
-    public void testPostString() {
+    public void testGetStringEmptyString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = "";
+        REST.withCallback(new MethodCallback<String>() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).getString(name);
+    }
+
+    public void testGetStringNullString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = null;
+        REST.withCallback(new MethodCallback<String>() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).getString(name);
+    }
+
+    public void testPostStringAnyString() {
         delayTestFinish(10000);
         ResteasyService resteasyService = GWT.create(ResteasyService.class);
 
@@ -118,6 +157,189 @@ public class ResteasyGwtJacksonTestGwt extends GWTTestCase {
                 fail(e.getMessage());
             }
         }).call(resteasyService).postString(name);
+    }
+
+    public void testPostStringEmptyString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = "";
+        REST.withCallback(new MethodCallback<String>() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).postString(name);
+    }
+
+    public void testPostStringNullString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = null;
+        REST.withCallback(new MethodCallback<String>() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).postString(name);
+    }
+
+    public void testGetStringAsPlainTextAnyString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = "Any string";
+        REST.withCallback(new TextCallback() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).getStringAsPlainText(name);
+    }
+
+    @Override
+    protected void reportUncaughtException(Throwable ex) {
+        if (ex instanceof ExpectedTestException) {
+            finishTest();
+            return;
+        }
+        super.reportUncaughtException(ex);
+    }
+
+    class ExpectedTestException extends RuntimeException {
+    }
+
+    public void testGetStringAsPlainTextNullStringException() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = null;
+        REST.withCallback(new TextCallback() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                throw new ExpectedTestException();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).getStringAsPlainText(name);
+    }
+
+    public void testGetStringAsPlainTextEmptyString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = "";
+        REST.withCallback(new TextCallback() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).getStringAsPlainText(name);
+    }
+
+    public void testGetStringAsPlainTextNullString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = null;
+        REST.withCallback(new TextCallback() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).getStringAsPlainText(name);
+    }
+
+    public void testPostStringAsPlainTextAnyString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = "Any string";
+        REST.withCallback(new TextCallback() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).postStringAsPlainText(name);
+    }
+
+    public void testPostStringAsPlainTextEmptyString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = "";
+        REST.withCallback(new TextCallback() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).postStringAsPlainText(name);
+    }
+
+    public void testPostStringAsPlainTextNullString() {
+        delayTestFinish(10000);
+        ResteasyService resteasyService = GWT.create(ResteasyService.class);
+
+        final String name = null;
+        REST.withCallback(new TextCallback() {
+            @Override
+            public void onSuccess(Method method, String response) {
+                assertEquals(name, response);
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(resteasyService).postStringAsPlainText(name);
     }
 
     @Nonnull

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/complex/ResteasyService.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/complex/ResteasyService.java
@@ -28,6 +28,7 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
@@ -45,6 +46,18 @@ public interface ResteasyService extends DirectRestService {
     @Path("postString")
     @Nullable
     String postString(@Nullable @FormParam("string") String string);
+
+    @GET
+    @Path("getStringAsPlainText")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Nullable
+    String getStringAsPlainText(@Nullable @QueryParam("string") String string);
+
+    @POST
+    @Path("getStringAsPlainText")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Nullable
+    String postStringAsPlainText(@Nullable @QueryParam("string") String string);
 
     @POST
     @Path("postBean")

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/complex/ResteasyServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/complex/ResteasyServlet.java
@@ -59,6 +59,18 @@ public class ResteasyServlet extends HttpServletDispatcher {
             return string;
         }
 
+        @Nullable
+        @Override
+        public String getStringAsPlainText(@Nullable String string) {
+            return string;
+        }
+
+        @Nullable
+        @Override
+        public String postStringAsPlainText(@Nullable String string) {
+            return string;
+        }
+
         @Nonnull
         @Override
         public Bean postBean(@Nonnull Bean bean) {


### PR DESCRIPTION
For method producing MediaType.TEXT_PLAIN, if your method returns the empty String "", AbstractRequestCallback converts it to null.

```java
@GET
@Produces(MediaType.TEXT_PLAIN)
String method();
```

For information purpose, if your method returns
- null, your backend should return an Http status code 204.
- the empty String "", your backend should return an Http status code 200 with an empty body.