### PR TITLE
Prevent null or empty HeaderParams to be set as HTTP headers

### DIFF
--- a/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/client/Method.java
@@ -74,6 +74,15 @@ public class Method {
                 setHeader("X-HTTP-Method-Override", method);
             }
         }
+
+		@Override
+		public void setHeader(String header, String value) {
+			// prevent setting null or empty string
+			if ((value == null) || (0 == value.trim().length()))
+				return;
+			super.setHeader(header, value);
+		}
+        
     }
 
     public RequestBuilder builder;


### PR DESCRIPTION
HTTP headers can not be empty per RFC 7230 (https://tools.ietf.org/html/rfc7230#section-3.2),
so prevent RestyGWT from setting them. If null or empty string is passed as header value,
simply do not emit that header line at all.

Closes #406.