### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,7 @@ matrix:
     - jdk: oraclejdk8
       script: cd restygwt-examples; mvn verify -Prun-examples -Dmaven.test.skip -pl restygwt-jersey-jaxb-example,restygwt-jersey-jaxson-example,restygwt-cxf-jaxson-example -s settings.xml
 
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
